### PR TITLE
feat: enable ride offer negotiation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { AuthProvider } from '@/contexts/auth-provider';
-import { Toaster } from "@/components/ui/toaster";
+import { NotificationProvider } from '@/contexts/notification-provider';
+import { Toaster } from '@/components/ui/toaster';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -28,8 +29,10 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <AuthProvider>
-          {children}
-          <Toaster />
+          <NotificationProvider>
+            {children}
+            <Toaster />
+          </NotificationProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/components/dashboard/driver-ride-card.tsx
+++ b/src/components/dashboard/driver-ride-card.tsx
@@ -58,8 +58,10 @@ import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   AlertTriangle,
+  ArrowLeftRight,
   CalendarIcon,
   CheckCircle,
+  HandCoins,
   Loader2,
   Pencil,
   Trash2,
@@ -69,9 +71,11 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
+  acceptRideRequest,
+  counterOfferRideRequest,
   deleteRide,
+  rejectRideRequest,
   updateRide,
-  updateRideRequestStatus,
 } from "@/lib/firestore-rides";
 import { rideFormSchema, type RideFormValues } from "@/lib/validators/ride";
 import { useToast } from "@/hooks/use-toast";
@@ -95,6 +99,11 @@ export function DriverRideCard({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isSavingRide, setIsSavingRide] = useState(false);
   const [isDeletingRide, setIsDeletingRide] = useState(false);
+  const [requestToCounter, setRequestToCounter] = useState<RideRequest | null>(
+    null,
+  );
+  const [counterOfferValue, setCounterOfferValue] = useState<string>("");
+  const [isSendingCounterOffer, setIsSendingCounterOffer] = useState(false);
 
   const form = useForm<RideFormValues>({
     resolver: zodResolver(rideFormSchema),
@@ -109,8 +118,11 @@ export function DriverRideCard({
     form.reset(mapRideToFormValues(ride));
   }, [ride, form]);
 
-  const pendingRequests = useMemo(
-    () => requests.filter((req) => req.status === "pending"),
+  const activeRequests = useMemo(
+    () =>
+      requests.filter(
+        (req) => req.status === "pending" || req.status === "countered",
+      ),
     [requests],
   );
   const acceptedRequests = useMemo(
@@ -124,52 +136,132 @@ export function DriverRideCard({
     return parsed && isValid(parsed) ? format(parsed, "PPP") : ride.date;
   }, [ride.date]);
 
-  const handleManageRequest = async (
-    requestId: string,
-    newStatus: "accepted" | "rejected",
-  ) => {
-    setProcessingRequestId(requestId);
-    const result = await updateRideRequestStatus(
-      requestId,
-      ride.id || "",
-      newStatus,
+  const updateRequestState = (updatedRequest: RideRequest) => {
+    if (!updatedRequest.id) return;
+    setRequests((prevRequests) =>
+      prevRequests.map((req) =>
+        req.id === updatedRequest.id ? updatedRequest : req,
+      ),
     );
+  };
+
+  const handleAcceptRequest = async (
+    request: RideRequest,
+    acceptedPrice: number,
+  ) => {
+    if (!request.id || !ride.id) {
+      toast({
+        title: "Acción no disponible",
+        description: "No se encontró la información necesaria de la solicitud.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setProcessingRequestId(request.id);
+    const result = await acceptRideRequest(request.id, ride.id, acceptedPrice);
+    setProcessingRequestId(null);
 
     if (result.success && result.updatedRequest) {
-      setRequests((prevRequests) =>
-        prevRequests.map((req) =>
-          req.id === requestId
-            ? (result.updatedRequest as RideRequest)
-            : req,
-        ),
-      );
+      updateRequestState(result.updatedRequest as RideRequest);
       toast({
-        title: `Solicitud ${
-          newStatus === "accepted" ? "aceptada" : "rechazada"
-        }`,
-        description: `Se ha ${
-          newStatus === "accepted" ? "aceptado" : "rechazado"
-        } correctamente la solicitud.`,
-        action:
-          newStatus === "accepted" ? (
-            <CheckCircle className="text-green-500" />
-          ) : (
-            <XCircle className="text-red-500" />
-          ),
+        title: "Solicitud aceptada",
+        description: `Confirmaste el viaje por $${acceptedPrice.toFixed(2)}.`,
+        action: <CheckCircle className="text-green-500" />,
       });
     } else {
       toast({
-        title: "Acción Fallida",
+        title: "No se pudo aceptar",
         description:
-          result.message ||
-          `No se pudo ${
-            newStatus === "accepted" ? "aceptar" : "rechazar"
-          } la solicitud.`,
+          result.message || "Intentalo de nuevo en unos instantes.",
         variant: "destructive",
         action: <AlertTriangle className="text-red-500" />,
       });
     }
+  };
+
+  const handleRejectRequest = async (request: RideRequest) => {
+    if (!request.id || !ride.id) {
+      toast({
+        title: "Acción no disponible",
+        description: "No se encontró la información necesaria de la solicitud.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setProcessingRequestId(request.id);
+    const result = await rejectRideRequest(request.id, ride.id);
     setProcessingRequestId(null);
+
+    if (result.success && result.updatedRequest) {
+      updateRequestState(result.updatedRequest as RideRequest);
+      toast({
+        title: "Solicitud rechazada",
+        description: "Le avisamos al pasajero del rechazo.",
+        action: <XCircle className="text-red-500" />,
+      });
+    } else {
+      toast({
+        title: "No se pudo rechazar",
+        description:
+          result.message || "Ocurrió un error al actualizar la solicitud.",
+        variant: "destructive",
+        action: <AlertTriangle className="text-red-500" />,
+      });
+    }
+  };
+
+  const openCounterOfferDialog = (request: RideRequest) => {
+    if (isSendingCounterOffer) return;
+    setRequestToCounter(request);
+    setCounterOfferValue(
+      (
+        request.counterOfferPrice ||
+        request.offeredPrice ||
+        request.price ||
+        ride.price ||
+        0
+      ).toString(),
+    );
+  };
+
+  const handleCounterOfferSubmit = async () => {
+    if (!requestToCounter?.id) return;
+    const parsedValue = Number(counterOfferValue);
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+      toast({
+        title: "Contraoferta inválida",
+        description: "Ingresá un monto válido para la contraoferta.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSendingCounterOffer(true);
+    const result = await counterOfferRideRequest(
+      requestToCounter.id,
+      parsedValue,
+    );
+    setIsSendingCounterOffer(false);
+
+    if (result.success && result.updatedRequest) {
+      updateRequestState(result.updatedRequest as RideRequest);
+      toast({
+        title: "Contraoferta enviada",
+        description: `Propusiste $${parsedValue.toFixed(2)} al pasajero.`,
+        action: <HandCoins className="text-primary" />,
+      });
+      setRequestToCounter(null);
+    } else {
+      toast({
+        title: "No se pudo contraofertar",
+        description:
+          result.message || "Reintentá más tarde.",
+        variant: "destructive",
+        action: <AlertTriangle className="text-red-500" />,
+      });
+    }
   };
 
   const handleEditSubmit = async (values: RideFormValues) => {
@@ -282,7 +374,7 @@ export function DriverRideCard({
         <Accordion type="single" collapsible className="w-full">
           <AccordionItem value="requests">
             <AccordionTrigger>
-              Ver Solicitudes ({pendingRequests.length} pendientes,{' '}
+              Ver Solicitudes ({activeRequests.length} en curso,{' '}
               {acceptedRequests.length} aceptadas)
             </AccordionTrigger>
             <AccordionContent>
@@ -292,75 +384,243 @@ export function DriverRideCard({
                 </p>
               ) : (
                 <div className="space-y-4 pt-2">
-                  {requests.map((request) => (
-                    <div
-                      key={request.id}
-                      className="p-3 border rounded-md bg-background/50"
-                    >
-                      <div className="flex justify-between items-center">
-                        <div>
-                          <p className="font-semibold">
-                            {request.passengerName}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            Solicitado el:{' '}
-                            {request.createdAt
-                              ? new Date(request.createdAt).toLocaleDateString()
-                              : 'N/A'}
-                          </p>
+                  {requests.map((request) => {
+                    const passengerOffer =
+                      typeof request.offeredPrice === "number"
+                        ? request.offeredPrice
+                        : typeof request.price === "number"
+                          ? request.price
+                          : ride.price;
+                    const badgeVariant =
+                      request.status === "accepted"
+                        ? "default"
+                        : request.status === "rejected"
+                          ? "destructive"
+                          : request.status === "countered"
+                            ? "outline"
+                            : "secondary";
+
+                    return (
+                      <div
+                        key={request.id}
+                        className="p-3 border rounded-md bg-background/50"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="font-semibold">
+                              {request.passengerName}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              Solicitado el:{' '}
+                              {request.createdAt
+                                ? new Date(request.createdAt).toLocaleDateString()
+                                : 'N/A'}
+                            </p>
+                          </div>
+                          <Badge variant={badgeVariant} className="capitalize">
+                            {request.status}
+                          </Badge>
                         </div>
-                        <Badge
-                          variant={
-                            request.status === "accepted"
-                              ? "default"
-                              : request.status === "rejected"
-                                ? "destructive"
-                                : "secondary"
-                          }
-                          className="capitalize"
-                        >
-                          {request.status}
-                        </Badge>
+
+                        <div className="mt-3 space-y-2 text-sm">
+                          <div className="flex items-center gap-2 text-muted-foreground">
+                            <HandCoins className="h-4 w-4 text-primary" />
+                            <span>
+                              Oferta del pasajero: $
+                              {passengerOffer.toFixed(2)}
+                            </span>
+                          </div>
+                          {request.counterOfferPrice !== null &&
+                          request.counterOfferPrice !== undefined ? (
+                            <div className="flex items-center gap-2 text-primary">
+                              <ArrowLeftRight className="h-4 w-4" />
+                              <span>
+                                Contraoferta enviada: $
+                                {request.counterOfferPrice.toFixed(2)}
+                              </span>
+                            </div>
+                          ) : null}
+                          {request.finalPrice && request.status === "accepted" ? (
+                            <div className="flex items-center gap-2 text-green-600">
+                              <CheckCircle className="h-4 w-4" />
+                              <span>
+                                Precio acordado: $
+                                {request.finalPrice.toFixed(2)}
+                              </span>
+                            </div>
+                          ) : null}
+                        </div>
+
+                        {request.status === "pending" ? (
+                          <div className="mt-4 flex flex-wrap gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="text-green-500 border-green-500 hover:bg-green-500/10 hover:text-green-600"
+                              onClick={() =>
+                                handleAcceptRequest(request, passengerOffer)
+                              }
+                              disabled={processingRequestId === request.id}
+                            >
+                              {processingRequestId === request.id && (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              )}
+                              <UserCheck className="mr-1 h-4 w-4" /> Aceptar
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="text-blue-500 border-blue-500 hover:bg-blue-500/10 hover:text-blue-600"
+                              onClick={() => openCounterOfferDialog(request)}
+                              disabled={processingRequestId === request.id}
+                            >
+                              <ArrowLeftRight className="mr-1 h-4 w-4" />
+                              Contraofertar
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="text-red-500 border-red-500 hover:bg-red-500/10 hover:text-red-600"
+                              onClick={() => handleRejectRequest(request)}
+                              disabled={processingRequestId === request.id}
+                            >
+                              {processingRequestId === request.id && (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              )}
+                              <UserX className="mr-1 h-4 w-4" /> Rechazar
+                            </Button>
+                          </div>
+                        ) : null}
+
+                        {request.status === "countered" ? (
+                          <div className="mt-4 space-y-2">
+                            <p className="text-xs text-muted-foreground">
+                              Contraoferta enviada. Esperando respuesta del pasajero.
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                onClick={() => openCounterOfferDialog(request)}
+                                disabled={
+                                  isSendingCounterOffer &&
+                                  requestToCounter?.id === request.id
+                                }
+                              >
+                                {isSendingCounterOffer &&
+                                requestToCounter?.id === request.id ? (
+                                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                ) : null}
+                                <ArrowLeftRight className="mr-1 h-4 w-4" />
+                                Editar contraoferta
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="text-red-500 border-red-500 hover:bg-red-500/10 hover:text-red-600"
+                                onClick={() => handleRejectRequest(request)}
+                                disabled={processingRequestId === request.id}
+                              >
+                                {processingRequestId === request.id && (
+                                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                )}
+                                <UserX className="mr-1 h-4 w-4" /> Rechazar
+                              </Button>
+                            </div>
+                          </div>
+                        ) : null}
+                        {request.status === "accepted" ? (
+                          <p className="mt-3 text-xs text-green-600">
+                            Pasajero confirmado. Coordiná los detalles del viaje.
+                          </p>
+                        ) : null}
+                        {request.status === "rejected" ? (
+                          <p className="mt-3 text-xs text-muted-foreground">
+                            Esta solicitud fue rechazada.
+                          </p>
+                        ) : null}
                       </div>
-                      {request.status === "pending" && (
-                        <div className="mt-3 flex space-x-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="text-green-500 border-green-500 hover:bg-green-500/10 hover:text-green-600"
-                            onClick={() =>
-                              handleManageRequest(request.id!, "accepted")
-                            }
-                            disabled={processingRequestId === request.id}
-                          >
-                            {processingRequestId === request.id && (
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            )}
-                            <UserCheck className="mr-1 h-4 w-4" /> Aceptar
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="text-red-500 border-red-500 hover:bg-red-500/10 hover:text-red-600"
-                            onClick={() =>
-                              handleManageRequest(request.id!, "rejected")
-                            }
-                            disabled={processingRequestId === request.id}
-                          >
-                            {processingRequestId === request.id && (
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            )}
-                            <UserX className="mr-1 h-4 w-4" /> Rechazar
-                          </Button>
-                        </div>
-                      )}
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </AccordionContent>
           </AccordionItem>
         </Accordion>
+        <Dialog
+          open={Boolean(requestToCounter)}
+          onOpenChange={(open) => {
+            if (!open && !isSendingCounterOffer) {
+              setRequestToCounter(null);
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Enviar contraoferta</DialogTitle>
+              <DialogDescription>
+                Proponé un nuevo precio para negociar con{' '}
+                {requestToCounter?.passengerName || "el pasajero"}.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-1 text-sm text-muted-foreground">
+                <p>
+                  Oferta del pasajero: $
+                  {requestToCounter
+                    ? (
+                        typeof requestToCounter.offeredPrice === "number"
+                          ? requestToCounter.offeredPrice
+                          : typeof requestToCounter.price === "number"
+                            ? requestToCounter.price
+                            : ride.price
+                      ).toFixed(2)
+                    : ride.price.toFixed(2)}
+                </p>
+                {requestToCounter?.counterOfferPrice ? (
+                  <p>
+                    Tu última contraoferta: $
+                    {requestToCounter.counterOfferPrice.toFixed(2)}
+                  </p>
+                ) : null}
+              </div>
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor={`counter-offer-${requestToCounter?.id ?? "ride"}`}
+                >
+                  Nuevo monto (en pesos)
+                </label>
+                <Input
+                  id={`counter-offer-${requestToCounter?.id ?? "ride"}`}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={counterOfferValue}
+                  onChange={(event) => setCounterOfferValue(event.target.value)}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setRequestToCounter(null)}
+                disabled={isSendingCounterOffer}
+              >
+                Cancelar
+              </Button>
+              <Button
+                onClick={handleCounterOfferSubmit}
+                disabled={isSendingCounterOffer}
+              >
+                {isSendingCounterOffer && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                Enviar contraoferta
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </CardContent>
       <CardFooter className="flex flex-col sm:flex-row gap-2">
         <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>

--- a/src/components/dashboard/driver-ride-card.tsx
+++ b/src/components/dashboard/driver-ride-card.tsx
@@ -159,7 +159,12 @@ export function DriverRideCard({
     }
 
     setProcessingRequestId(request.id);
-    const result = await acceptRideRequest(request.id, ride.id, acceptedPrice);
+    const result = await acceptRideRequest(
+      request.id,
+      ride.id,
+      acceptedPrice,
+      "driver",
+    );
     setProcessingRequestId(null);
 
     if (result.success && result.updatedRequest) {
@@ -191,7 +196,7 @@ export function DriverRideCard({
     }
 
     setProcessingRequestId(request.id);
-    const result = await rejectRideRequest(request.id, ride.id);
+    const result = await rejectRideRequest(request.id, ride.id, "driver");
     setProcessingRequestId(null);
 
     if (result.success && result.updatedRequest) {

--- a/src/components/dashboard/passenger-request-card.tsx
+++ b/src/components/dashboard/passenger-request-card.tsx
@@ -73,7 +73,11 @@ export function PassengerRequestCard({ request }: PassengerRequestCardProps) {
   const handleReject = async () => {
     if (!request.id) return;
     setCurrentAction("reject");
-    const result = await rejectRideRequest(request.id, request.rideId);
+    const result = await rejectRideRequest(
+      request.id,
+      request.rideId,
+      "passenger",
+    );
     setCurrentAction(null);
 
     if (result.success) {
@@ -113,6 +117,7 @@ export function PassengerRequestCard({ request }: PassengerRequestCardProps) {
       request.id,
       request.rideId,
       request.counterOfferPrice,
+      "passenger",
     );
     setCurrentAction(null);
 

--- a/src/components/dashboard/passenger-request-card.tsx
+++ b/src/components/dashboard/passenger-request-card.tsx
@@ -1,48 +1,209 @@
 "use client";
 
+import { useState } from "react";
 import type { RideRequest } from "@/types";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { CalendarDays, Clock, MapPin, CircleDollarSign, CheckCircle, XCircle, Loader2 } from "lucide-react";
+import {
+  CalendarDays,
+  Clock,
+  MapPin,
+  CircleDollarSign,
+  CheckCircle,
+  XCircle,
+  Loader2,
+  ArrowLeftRight,
+  HandCoins,
+  AlertTriangle,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import {
+  acceptRideRequest,
+  rejectRideRequest,
+  updateRideRequestOffer,
+} from "@/lib/firestore-rides";
 
 interface PassengerRequestCardProps {
   request: RideRequest;
 }
 
+type PassengerAction = "accept" | "reject" | "offer" | null;
+
 export function PassengerRequestCard({ request }: PassengerRequestCardProps) {
+  const { toast } = useToast();
+  const [currentAction, setCurrentAction] = useState<PassengerAction>(null);
+  const [isOfferDialogOpen, setIsOfferDialogOpen] = useState(false);
+  const [offerValue, setOfferValue] = useState(
+    () => (request.offeredPrice ?? request.price ?? 0).toString(),
+  );
+
   let statusColor: "default" | "secondary" | "destructive" | "outline" | null | undefined = "secondary";
   let StatusIcon = Loader2;
 
   switch (request.status) {
-    case 'accepted':
-      statusColor = "default"; // verde en algunos temas
+    case "accepted":
+      statusColor = "default";
       StatusIcon = CheckCircle;
       break;
-    case 'rejected':
+    case "rejected":
       statusColor = "destructive";
       StatusIcon = XCircle;
       break;
-    case 'pending':
-      statusColor = "secondary"; // amarillo/gris
+    case "countered":
+      statusColor = "outline";
+      StatusIcon = ArrowLeftRight;
+      break;
+    case "pending":
+    default:
+      statusColor = "secondary";
       StatusIcon = Loader2;
       break;
   }
+
+  const handleReject = async () => {
+    if (!request.id) return;
+    setCurrentAction("reject");
+    const result = await rejectRideRequest(request.id, request.rideId);
+    setCurrentAction(null);
+
+    if (result.success) {
+      toast({
+        title: "Solicitud cancelada",
+        description: "Notificamos al conductor que cancelaste la solicitud.",
+        action: <XCircle className="text-red-500" />,
+      });
+    } else {
+      toast({
+        title: "No se pudo cancelar",
+        description:
+          result.message || "Intentá nuevamente en unos instantes.",
+        variant: "destructive",
+        action: <AlertTriangle className="text-red-500" />,
+      });
+    }
+  };
+
+  const handleAcceptCounterOffer = async () => {
+    if (
+      !request.id ||
+      request.counterOfferPrice === null ||
+      request.counterOfferPrice === undefined ||
+      request.counterOfferPrice <= 0
+    ) {
+      toast({
+        title: "Contraoferta inválida",
+        description: "No encontramos la contraoferta del conductor.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setCurrentAction("accept");
+    const result = await acceptRideRequest(
+      request.id,
+      request.rideId,
+      request.counterOfferPrice,
+    );
+    setCurrentAction(null);
+
+    if (result.success) {
+      toast({
+        title: "Viaje confirmado",
+        description: "Aceptaste la contraoferta del conductor.",
+        action: <CheckCircle className="text-green-500" />,
+      });
+    } else {
+      toast({
+        title: "No se pudo confirmar",
+        description:
+          result.message || "Ocurrió un error al aceptar la contraoferta.",
+        variant: "destructive",
+        action: <AlertTriangle className="text-red-500" />,
+      });
+    }
+  };
+
+  const handleSubmitOffer = async () => {
+    if (!request.id) return;
+    const parsedOffer = Number(offerValue);
+    if (!Number.isFinite(parsedOffer) || parsedOffer <= 0) {
+      toast({
+        title: "Oferta inválida",
+        description: "Ingresá un monto válido para tu nueva oferta.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setCurrentAction("offer");
+    const result = await updateRideRequestOffer(request.id, parsedOffer);
+    setCurrentAction(null);
+
+    if (result.success) {
+      toast({
+        title: "Oferta enviada",
+        description: "Actualizamos la oferta y avisamos al conductor.",
+        action: <HandCoins className="text-primary" />,
+      });
+      setIsOfferDialogOpen(false);
+    } else {
+      toast({
+        title: "No se pudo enviar",
+        description:
+          result.message || "Intentá de nuevo más tarde.",
+        variant: "destructive",
+        action: <AlertTriangle className="text-red-500" />,
+      });
+    }
+  };
+
+  const pendingMessage = (() => {
+    switch (request.status) {
+      case "pending":
+        return "Esperando la respuesta del conductor.";
+      case "countered":
+        return "El conductor te envió una contraoferta.";
+      case "accepted":
+        return request.finalPrice
+          ? `Solicitud confirmada por $${request.finalPrice.toFixed(2)}.`
+          : "Solicitud confirmada.";
+      case "rejected":
+      default:
+        return "La solicitud fue rechazada.";
+    }
+  })();
 
   return (
     <Card className="w-full shadow-lg">
       <CardHeader>
         <div className="flex justify-between items-start">
           <div>
-            <CardTitle className="text-xl">{request.origin || "N/A"} a {request.destination || "N/A"}</CardTitle>
-            <CardDescription>Conductor: {request.driverName || "N/A"} (ID del Viaje: {request.rideId})</CardDescription>
+            <CardTitle className="text-xl">
+              {request.origin || "N/A"} a {request.destination || "N/A"}
+            </CardTitle>
+            <CardDescription>
+              Conductor: {request.driverName || "N/A"} (ID del Viaje: {request.rideId})
+            </CardDescription>
           </div>
           <Badge variant={statusColor} className="capitalize flex items-center gap-1">
-            <StatusIcon className={`h-4 w-4 ${request.status === 'pending' ? 'animate-spin' : ''}`} />
+            <StatusIcon
+              className={`h-4 w-4 ${request.status === "pending" ? "animate-spin" : ""}`}
+            />
             {request.status}
           </Badge>
         </div>
       </CardHeader>
-      <CardContent className="space-y-2">
+      <CardContent className="space-y-3">
         <div className="flex items-center text-sm text-muted-foreground">
           <CalendarDays className="mr-2 h-4 w-4 text-primary" />
           <span>{request.date ? new Date(request.date).toLocaleDateString() : "N/A"}</span>
@@ -51,15 +212,183 @@ export function PassengerRequestCard({ request }: PassengerRequestCardProps) {
           <Clock className="mr-2 h-4 w-4 text-primary" />
           <span>{request.time || "N/A"}</span>
         </div>
-        <div className="flex items-center text-sm">
-          <CircleDollarSign className="mr-2 h-4 w-4 text-primary" />
-          <span className="font-medium">${typeof request.price === 'number' ? request.price.toFixed(2) : "N/A"}</span>
+        <div className="flex items-center text-sm text-muted-foreground">
+          <MapPin className="mr-2 h-4 w-4 text-primary" />
+          <span>Desde: {request.origin || "N/A"}</span>
         </div>
-        <p className="text-xs text-muted-foreground pt-2">
-          Solicitado el: {request.createdAt ? new Date(request.createdAt).toLocaleString() : 'N/A'}
+        <div className="flex items-center text-sm text-muted-foreground">
+          <MapPin className="mr-2 h-4 w-4 text-primary" />
+          <span>Hacia: {request.destination || "N/A"}</span>
+        </div>
+        <div className="space-y-1 pt-2">
+          <div className="flex items-center text-sm">
+            <CircleDollarSign className="mr-2 h-4 w-4 text-primary" />
+            <span className="font-medium">
+              Precio publicado: $
+              {typeof request.price === "number"
+                ? request.price.toFixed(2)
+                : "N/A"}
+            </span>
+          </div>
+          <div className="flex items-center text-sm">
+            <HandCoins className="mr-2 h-4 w-4 text-primary" />
+            <span>
+              Tu oferta: $
+              {typeof request.offeredPrice === "number"
+                ? request.offeredPrice.toFixed(2)
+                : "N/A"}
+            </span>
+          </div>
+          {request.counterOfferPrice !== null &&
+          request.counterOfferPrice !== undefined ? (
+            <div className="flex items-center text-sm text-primary">
+              <ArrowLeftRight className="mr-2 h-4 w-4" />
+              <span>
+                Contraoferta del conductor: $
+                {request.counterOfferPrice.toFixed(2)}
+              </span>
+            </div>
+          ) : null}
+          {request.finalPrice && request.status === "accepted" ? (
+            <div className="flex items-center text-sm text-green-600">
+              <CheckCircle className="mr-2 h-4 w-4" />
+              <span>
+                Precio acordado: ${request.finalPrice.toFixed(2)}
+              </span>
+            </div>
+          ) : null}
+        </div>
+
+        <p className="text-sm text-muted-foreground">{pendingMessage}</p>
+
+        <p className="text-xs text-muted-foreground">
+          Solicitado el: {request.createdAt ? new Date(request.createdAt).toLocaleString() : "N/A"}
         </p>
+
+        {request.status === "pending" ? (
+          <div className="flex flex-wrap gap-2 pt-2">
+            <Button size="sm" onClick={() => {
+              setOfferValue(
+                (request.offeredPrice ?? request.price ?? 0).toString(),
+              );
+              setIsOfferDialogOpen(true);
+            }}>
+              Actualizar oferta
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleReject}
+              disabled={currentAction === "reject"}
+            >
+              {currentAction === "reject" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Cancelar solicitud
+            </Button>
+          </div>
+        ) : null}
+
+        {request.status === "countered" ? (
+          <div className="flex flex-wrap gap-2 pt-2">
+            <Button
+              size="sm"
+              onClick={handleAcceptCounterOffer}
+              disabled={currentAction === "accept"}
+            >
+              {currentAction === "accept" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Aceptar contraoferta
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => {
+                setOfferValue(
+                  (
+                    request.counterOfferPrice ??
+                    request.offeredPrice ??
+                    request.price ??
+                    0
+                  ).toString(),
+                );
+                setIsOfferDialogOpen(true);
+              }}
+              disabled={currentAction === "offer"}
+            >
+              {currentAction === "offer" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Hacer nueva oferta
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleReject}
+              disabled={currentAction === "reject"}
+            >
+              {currentAction === "reject" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Rechazar
+            </Button>
+          </div>
+        ) : null}
       </CardContent>
-      {/* Opcionalmente agregar un botón de cancelar si el estado es "pending" */}
+
+      <Dialog open={isOfferDialogOpen} onOpenChange={setIsOfferDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Proponer una nueva oferta</DialogTitle>
+            <DialogDescription>
+              Ajustá el monto que querés ofrecer al conductor.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm text-muted-foreground">
+                Oferta actual: $
+                {(request.offeredPrice ?? request.price ?? 0).toFixed(2)}
+              </p>
+              {request.counterOfferPrice !== null &&
+              request.counterOfferPrice !== undefined ? (
+                <p className="text-sm text-muted-foreground">
+                  Contraoferta vigente: $
+                  {request.counterOfferPrice.toFixed(2)}
+                </p>
+              ) : null}
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor={`passenger-offer-${request.id}`}>
+                Nuevo monto (en pesos)
+              </label>
+              <Input
+                id={`passenger-offer-${request.id}`}
+                type="number"
+                min="0"
+                step="0.01"
+                value={offerValue}
+                onChange={(event) => setOfferValue(event.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsOfferDialogOpen(false)}>
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleSubmitOffer}
+              disabled={currentAction === "offer"}
+            >
+              {currentAction === "offer" && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Enviar oferta
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,8 +1,23 @@
 "use client";
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Car, LogIn, LogOut, PlusCircle, Search, User, UserPlus, LayoutDashboard } from 'lucide-react';
+import {
+  Car,
+  LogIn,
+  LogOut,
+  PlusCircle,
+  Search,
+  User,
+  UserPlus,
+  LayoutDashboard,
+  Bell,
+  ArrowLeftRight,
+  XCircle,
+  HandCoins,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { useAuth } from '@/contexts/auth-provider';
 import { Button } from '@/components/ui/button';
 import { auth } from '@/config/firebase';
@@ -16,10 +31,31 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { formatDistanceToNow } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { useNotifications } from '@/contexts/notification-provider';
+import type { NotificationType } from '@/contexts/notification-provider';
+import { cn } from '@/lib/utils';
+
+const notificationIcons: Record<NotificationType, { Icon: LucideIcon; className: string }> = {
+  "new-request": { Icon: HandCoins, className: "text-primary" },
+  "counter-offer": { Icon: ArrowLeftRight, className: "text-amber-500" },
+  rejection: { Icon: XCircle, className: "text-destructive" },
+};
 
 export function Navbar() {
   const { user } = useAuth();
   const router = useRouter();
+  const { notifications, unreadCount, markAllAsRead } = useNotifications();
+  const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
+  const latestNotifications = notifications.slice(0, 10);
+
+  const handleNotificationsOpenChange = (open: boolean) => {
+    setIsNotificationsOpen(open);
+    if (open) {
+      markAllAsRead();
+    }
+  };
 
   const handleLogout = async () => {
     try {
@@ -58,51 +94,152 @@ export function Navbar() {
             </Button>
             
             {user ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className="relative h-10 w-10 rounded-full">
-                    <Avatar className="h-10 w-10">
-                      <AvatarImage src={user.photoURL || undefined} alt={user.displayName || user.email || "Usuario"} />
-                      <AvatarFallback>{getInitials(user.displayName || user.email)}</AvatarFallback>
-                    </Avatar>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-56" align="end" forceMount>
-                  <DropdownMenuLabel className="font-normal">
-                    <div className="flex flex-col space-y-1">
-                      <p className="text-sm font-medium leading-none">
-                        {user.displayName || "Usuario"}
-                      </p>
-                      <p className="text-xs leading-none text-muted-foreground">
-                        {user.email}
-                      </p>
-                    </div>
-                  </DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <Link href="/dashboard/conductor">
-                      <LayoutDashboard className="mr-2 h-4 w-4" />
-                      Panel del Conductor
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                     <Link href="/dashboard/pasajero">
-                       <User className="mr-2 h-4 w-4" />
-                       Panel del Pasajero
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={handleLogout} className="cursor-pointer">
-                    <LogOut className="mr-2 h-4 w-4" />
-                    Cerrar Sesión
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <>
+                <DropdownMenu
+                  open={isNotificationsOpen}
+                  onOpenChange={handleNotificationsOpenChange}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="relative h-10 w-10 rounded-full"
+                      aria-label={
+                        unreadCount > 0
+                          ? `Tenés ${unreadCount} notificaciones sin leer`
+                          : "Notificaciones"
+                      }
+                    >
+                      <Bell className="h-5 w-5" />
+                      {unreadCount > 0 && (
+                        <span className="absolute -right-1 -top-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold text-destructive-foreground">
+                          {unreadCount > 9 ? "9+" : unreadCount}
+                        </span>
+                      )}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-80 p-0"
+                    align="end"
+                    sideOffset={12}
+                    forceMount
+                  >
+                    <DropdownMenuLabel className="flex items-center justify-between px-4 py-3 font-semibold">
+                      <span>Notificaciones</span>
+                      {unreadCount > 0 ? (
+                        <span className="text-xs text-destructive">
+                          {unreadCount} nuevas
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Al día</span>
+                      )}
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {latestNotifications.length === 0 ? (
+                      <div className="p-4 text-sm text-muted-foreground">
+                        No tenés notificaciones por ahora.
+                      </div>
+                    ) : (
+                      <div className="max-h-80 overflow-y-auto py-1">
+                        {latestNotifications.map((notification) => {
+                          const iconConfig = notificationIcons[notification.type];
+                          const IconComponent = iconConfig.Icon;
+                          const relativeTime = formatDistanceToNow(
+                            notification.createdAt,
+                            { addSuffix: true, locale: es },
+                          );
+
+                          return (
+                            <div
+                              key={notification.id}
+                              className={cn(
+                                "flex items-start gap-3 px-4 py-3 text-sm transition-colors",
+                                notification.read
+                                  ? "hover:bg-muted/60"
+                                  : "bg-muted/60 hover:bg-muted",
+                              )}
+                            >
+                              <div className="mt-0.5">
+                                <div
+                                  className={cn(
+                                    "flex h-8 w-8 items-center justify-center rounded-full",
+                                    notification.read
+                                      ? "bg-muted text-muted-foreground"
+                                      : "bg-background",
+                                  )}
+                                >
+                                  <IconComponent
+                                    className={cn(
+                                      "h-4 w-4",
+                                      iconConfig.className,
+                                    )}
+                                  />
+                                </div>
+                              </div>
+                              <div className="flex-1 space-y-1">
+                                <p className="font-medium leading-tight">
+                                  {notification.title}
+                                </p>
+                                <p className="text-xs leading-snug text-muted-foreground">
+                                  {notification.description}
+                                </p>
+                                <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                                  {relativeTime}
+                                </p>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" className="relative h-10 w-10 rounded-full">
+                      <Avatar className="h-10 w-10">
+                        <AvatarImage src={user.photoURL || undefined} alt={user.displayName || user.email || "Usuario"} />
+                        <AvatarFallback>{getInitials(user.displayName || user.email)}</AvatarFallback>
+                      </Avatar>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent className="w-56" align="end" forceMount>
+                    <DropdownMenuLabel className="font-normal">
+                      <div className="flex flex-col space-y-1">
+                        <p className="text-sm font-medium leading-none">
+                          {user.displayName || "Usuario"}
+                        </p>
+                        <p className="text-xs leading-none text-muted-foreground">
+                          {user.email}
+                        </p>
+                      </div>
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                      <Link href="/dashboard/conductor">
+                        <LayoutDashboard className="mr-2 h-4 w-4" />
+                        Panel del Conductor
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link href="/dashboard/pasajero">
+                        <User className="mr-2 h-4 w-4" />
+                        Panel del Pasajero
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={handleLogout} className="cursor-pointer">
+                      <LogOut className="mr-2 h-4 w-4" />
+                      Cerrar Sesión
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
             ) : (
               <>
                 <Button variant="ghost" size="sm" asChild>
                   <Link href="/login">
-                    <LogIn className="mr-1 h-4 w-4 sm:mr-2" /> 
+                    <LogIn className="mr-1 h-4 w-4 sm:mr-2" />
                     <span className="hidden sm:inline">Iniciar Sesión</span>
                   </Link>
                 </Button>
@@ -114,21 +251,21 @@ export function Navbar() {
                 </Button>
               </>
             )}
-             <DropdownMenu>
-                <DropdownMenuTrigger asChild className="sm:hidden">
-                  <Button variant="ghost" size="icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-menu"><line x1="4" x2="20" y1="12" y2="12"/><line x1="4" x2="20" y1="6" y2="6"/><line x1="4" x2="20" y1="18" y2="18"/></svg>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem asChild>
-                    <Link href="/buscar-viajes">Buscar Viajes</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href="/crear-viaje">Ofrecer Viaje</Link>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild className="sm:hidden">
+                <Button variant="ghost" size="icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-menu"><line x1="4" x2="20" y1="12" y2="12"/><line x1="4" x2="20" y1="6" y2="6"/><line x1="4" x2="20" y1="18" y2="18"/></svg>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <Link href="/buscar-viajes">Buscar Viajes</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/crear-viaje">Ofrecer Viaje</Link>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/src/components/rides/ride-card.tsx
+++ b/src/components/rides/ride-card.tsx
@@ -3,7 +3,24 @@
 import type { Ride } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { CalendarDays, Clock, MapPin, Users, CircleDollarSign, CheckCircle, AlertTriangle } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  CalendarDays,
+  Clock,
+  MapPin,
+  Users,
+  CircleDollarSign,
+  CheckCircle,
+  AlertTriangle,
+} from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/auth-provider";
 import { requestRide } from "@/lib/firestore-rides";
@@ -18,21 +35,48 @@ export function RideCard({ ride }: RideCardProps) {
   const { toast } = useToast();
   const { user } = useAuth();
   const [isRequesting, setIsRequesting] = useState(false);
+  const [isOfferDialogOpen, setIsOfferDialogOpen] = useState(false);
+  const [offerValue, setOfferValue] = useState(() => ride.price.toString());
 
-  const handleRequestRide = async () => {
+  const handleOpenOfferDialog = () => {
     if (!user) {
-      toast({ 
-        title: "Inicia Sesión", 
-        description: "Debés iniciar sesión para solicitar un viaje.", 
-        variant: "destructive" 
+      toast({
+        title: "Inicia Sesión",
+        description: "Debés iniciar sesión para solicitar un viaje.",
+        variant: "destructive",
       });
       return;
     }
+
     if (user.uid === ride.driverUid) {
-      toast({ 
-        title: "Acción No Permitida", 
-        description: "No puedes solicitar tu propio viaje.", 
-        variant: "destructive" 
+      toast({
+        title: "Acción No Permitida",
+        description: "No puedes solicitar tu propio viaje.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setOfferValue((ride.price ?? 0).toString());
+    setIsOfferDialogOpen(true);
+  };
+
+  const handleRequestRide = async () => {
+    const parsedOffer = Number(offerValue);
+    if (!Number.isFinite(parsedOffer) || parsedOffer <= 0) {
+      toast({
+        title: "Oferta inválida",
+        description: "Ingresá un monto válido para tu oferta.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!user) {
+      toast({
+        title: "Inicia Sesión",
+        description: "Debés iniciar sesión para solicitar un viaje.",
+        variant: "destructive",
       });
       return;
     }
@@ -49,20 +93,22 @@ export function RideCard({ ride }: RideCardProps) {
       date: ride.date,
       time: ride.time,
       price: ride.price,
+      offeredPrice: parsedOffer,
     });
 
     if (result.success) {
-      toast({ 
-        title: "Viaje Solicitado!", 
-        description: "Tu solicitud fue enviada al conductor.",
-        action: <CheckCircle className="text-green-500" />
+      toast({
+        title: "Viaje Solicitado!",
+        description: "Tu oferta fue enviada al conductor para su revisión.",
+        action: <CheckCircle className="text-green-500" />,
       });
+      setIsOfferDialogOpen(false);
     } else {
-      toast({ 
-        title: "Solicitud Fallida", 
-        description: result.message || "No se pudo enviar la solicitud.", 
+      toast({
+        title: "Solicitud Fallida",
+        description: result.message || "No se pudo enviar la solicitud.",
         variant: "destructive",
-        action: <AlertTriangle className="text-red-500" />
+        action: <AlertTriangle className="text-red-500" />,
       });
     }
     setIsRequesting(false);
@@ -102,14 +148,63 @@ export function RideCard({ ride }: RideCardProps) {
       </CardContent>
       <CardFooter>
         {user?.uid !== ride.driverUid ? (
-          <Button className="w-full" onClick={handleRequestRide} disabled={isRequesting || ride.availableSeats === 0}>
-            {isRequesting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {ride.availableSeats > 0 ? 'Solicitar Viaje' : 'No Hay Lugares Disponibles'}
+          <Button
+            className="w-full"
+            onClick={handleOpenOfferDialog}
+            disabled={ride.availableSeats === 0}
+          >
+            {ride.availableSeats > 0
+              ? "Solicitar Viaje"
+              : "No Hay Lugares Disponibles"}
           </Button>
         ) : (
-          <Button className="w-full" disabled variant="outline">Este es tu viaje</Button>
+          <Button className="w-full" disabled variant="outline">
+            Este es tu viaje
+          </Button>
         )}
       </CardFooter>
+
+      <Dialog open={isOfferDialogOpen} onOpenChange={setIsOfferDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Ofertar un lugar</DialogTitle>
+            <DialogDescription>
+              Proponé el precio que estás dispuesto a pagar por este viaje.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm text-muted-foreground">
+                Precio sugerido del viaje: ${ride.price.toFixed(2)}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor={`offer-${ride.id}`}>
+                Tu oferta (en pesos)
+              </label>
+              <Input
+                id={`offer-${ride.id}`}
+                type="number"
+                min="0"
+                step="0.01"
+                value={offerValue}
+                onChange={(event) => setOfferValue(event.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsOfferDialogOpen(false)}>
+              Cancelar
+            </Button>
+            <Button onClick={handleRequestRide} disabled={isRequesting}>
+              {isRequesting && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Enviar oferta
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/contexts/notification-provider.tsx
+++ b/src/contexts/notification-provider.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAuth } from "@/contexts/auth-provider";
+import type { RideRequest } from "@/types";
+import {
+  subscribeToDriverRequests,
+  subscribeToPassengerRequests,
+} from "@/lib/firestore-rides";
+import { useToast } from "@/hooks/use-toast";
+
+const MAX_NOTIFICATIONS = 30;
+const LAST_SEEN_STORAGE_KEY = "rc:last-seen";
+
+export type NotificationType = "new-request" | "counter-offer" | "rejection";
+export type NotificationSource = "driver" | "passenger";
+
+export type NotificationEntry = {
+  id: string;
+  type: NotificationType;
+  source: NotificationSource;
+  title: string;
+  description: string;
+  createdAt: Date;
+  read: boolean;
+  requestId?: string;
+  rideId?: string;
+};
+
+interface NotificationContextValue {
+  notifications: NotificationEntry[];
+  unreadCount: number;
+  markAllAsRead: () => void;
+}
+
+const NotificationContext =
+  createContext<NotificationContextValue | undefined>(undefined);
+
+const currencyFormatter =
+  typeof Intl !== "undefined"
+    ? new Intl.NumberFormat("es-AR", {
+        style: "currency",
+        currency: "ARS",
+        maximumFractionDigits: 0,
+      })
+    : null;
+
+function formatCurrency(value?: number | null) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "$0";
+  }
+
+  return currencyFormatter
+    ? currencyFormatter.format(value)
+    : `$${value.toFixed(0)}`;
+}
+
+function resolveEventDate(request: RideRequest) {
+  return (
+    request.statusUpdatedAt ??
+    request.createdAt ??
+    new Date()
+  );
+}
+
+function buildNotificationId(
+  request: RideRequest,
+  type: NotificationType,
+  timestamp: number,
+) {
+  const baseId = request.id || request.requestKey || `${request.rideId}-${type}`;
+  return `${baseId}:${type}:${timestamp}`;
+}
+
+function loadLastSeen(uid: string, role: NotificationSource) {
+  if (typeof window === "undefined") return Date.now();
+  const stored = window.localStorage.getItem(
+    `${LAST_SEEN_STORAGE_KEY}:${uid}:${role}`,
+  );
+  if (!stored) return Date.now();
+  const parsed = Number(stored);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function persistLastSeen(uid: string, role: NotificationSource, value: number) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    `${LAST_SEEN_STORAGE_KEY}:${uid}:${role}`,
+    value.toString(),
+  );
+}
+
+function triggerBrowserNotification(entry: NotificationEntry) {
+  if (typeof window === "undefined") return false;
+  if (!("Notification" in window)) return false;
+
+  if (window.Notification.permission === "granted") {
+    new window.Notification(entry.title, {
+      body: entry.description,
+      tag: entry.id,
+    });
+    return true;
+  }
+
+  if (window.Notification.permission === "default") {
+    window.Notification.requestPermission().then((permission) => {
+      if (permission === "granted") {
+        new window.Notification(entry.title, {
+          body: entry.description,
+          tag: entry.id,
+        });
+      }
+    });
+  }
+
+  return false;
+}
+
+function createDriverPendingNotification(request: RideRequest): NotificationEntry {
+  const eventDate = resolveEventDate(request);
+  const timestamp = eventDate.getTime();
+  const isUpdatedOffer =
+    request.statusUpdatedAt &&
+    request.createdAt &&
+    request.statusUpdatedAt.getTime() > request.createdAt.getTime();
+  const passengerName = request.passengerName || "Un pasajero";
+  const route =
+    request.origin && request.destination
+      ? `para el viaje de ${request.origin} a ${request.destination}`
+      : "para tu viaje";
+  const price = formatCurrency(request.offeredPrice ?? request.price ?? null);
+
+  return {
+    id: buildNotificationId(request, "new-request", timestamp),
+    type: "new-request",
+    source: "driver",
+    title: isUpdatedOffer
+      ? "El pasajero actualizó su oferta"
+      : "Nueva solicitud de viaje",
+    description: isUpdatedOffer
+      ? `${passengerName} propuso ${price} ${route}.`
+      : `${passengerName} solicitó un lugar ${route} por ${price}.`,
+    createdAt: eventDate,
+    read: false,
+    requestId: request.id,
+    rideId: request.rideId,
+  };
+}
+
+function createDriverCancellationNotification(
+  request: RideRequest,
+): NotificationEntry {
+  const eventDate = resolveEventDate(request);
+  const timestamp = eventDate.getTime();
+  const passengerName = request.passengerName || "El pasajero";
+  const route =
+    request.origin && request.destination
+      ? `del viaje de ${request.origin} a ${request.destination}`
+      : "de tu viaje";
+
+  return {
+    id: buildNotificationId(request, "rejection", timestamp),
+    type: "rejection",
+    source: "driver",
+    title: "El pasajero canceló la solicitud",
+    description: `${passengerName} canceló la solicitud ${route}.`,
+    createdAt: eventDate,
+    read: false,
+    requestId: request.id,
+    rideId: request.rideId,
+  };
+}
+
+function createPassengerCounterOfferNotification(
+  request: RideRequest,
+): NotificationEntry {
+  const eventDate = resolveEventDate(request);
+  const timestamp = eventDate.getTime();
+  const driverName = request.driverName || "El conductor";
+  const route =
+    request.origin && request.destination
+      ? `para el viaje de ${request.origin} a ${request.destination}`
+      : "para tu viaje";
+  const price = formatCurrency(
+    request.counterOfferPrice ?? request.price ?? null,
+  );
+
+  return {
+    id: buildNotificationId(request, "counter-offer", timestamp),
+    type: "counter-offer",
+    source: "passenger",
+    title: "Nueva contraoferta",
+    description: `${driverName} ofrece ${price} ${route}.`,
+    createdAt: eventDate,
+    read: false,
+    requestId: request.id,
+    rideId: request.rideId,
+  };
+}
+
+function createPassengerRejectionNotification(
+  request: RideRequest,
+): NotificationEntry {
+  const eventDate = resolveEventDate(request);
+  const timestamp = eventDate.getTime();
+  const driverName = request.driverName || "El conductor";
+  const route =
+    request.origin && request.destination
+      ? `para el viaje de ${request.origin} a ${request.destination}`
+      : "para tu viaje";
+
+  return {
+    id: buildNotificationId(request, "rejection", timestamp),
+    type: "rejection",
+    source: "passenger",
+    title: "Tu solicitud fue rechazada",
+    description: `${driverName} rechazó tu solicitud ${route}.`,
+    createdAt: eventDate,
+    read: false,
+    requestId: request.id,
+    rideId: request.rideId,
+  };
+}
+
+export function NotificationProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+  const notificationsRef = useRef<NotificationEntry[]>([]);
+  const seenEventsRef = useRef<Set<string>>(new Set());
+  const driverLastSeenRef = useRef<number>(Date.now());
+  const passengerLastSeenRef = useRef<number>(Date.now());
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (!user?.uid) {
+      notificationsRef.current = [];
+      setNotifications([]);
+      seenEventsRef.current.clear();
+      driverLastSeenRef.current = Date.now();
+      passengerLastSeenRef.current = Date.now();
+      setIsReady(false);
+      return;
+    }
+
+    notificationsRef.current = [];
+    setNotifications([]);
+    seenEventsRef.current.clear();
+    driverLastSeenRef.current = loadLastSeen(user.uid, "driver");
+    passengerLastSeenRef.current = loadLastSeen(user.uid, "passenger");
+    setIsReady(true);
+  }, [user?.uid]);
+
+  const pushNotifications = useCallback(
+    (entries: NotificationEntry[]) => {
+      if (!entries.length) return;
+      const existingIds = new Set(
+        notificationsRef.current.map((notification) => notification.id),
+      );
+
+      const deduped = entries.filter((entry) => {
+        if (seenEventsRef.current.has(entry.id)) return false;
+        if (existingIds.has(entry.id)) return false;
+        seenEventsRef.current.add(entry.id);
+        return true;
+      });
+
+      if (!deduped.length) return;
+
+      const merged = [...deduped, ...notificationsRef.current]
+        .sort(
+          (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+        )
+        .slice(0, MAX_NOTIFICATIONS);
+
+      notificationsRef.current = merged;
+      setNotifications(merged);
+
+      deduped.forEach((entry) => {
+        const didPush = triggerBrowserNotification(entry);
+        toast({
+          title: entry.title,
+          description: entry.description,
+          variant: entry.type === "rejection" ? "destructive" : "default",
+          duration: didPush ? 4000 : 5000,
+        });
+      });
+    },
+    [toast],
+  );
+
+  const processDriverRequests = useCallback(
+    (requests: RideRequest[]) => {
+      if (!user?.uid) return;
+
+      const driverCutoff = driverLastSeenRef.current;
+      const entries: NotificationEntry[] = [];
+
+      requests.forEach((request) => {
+        if (!request.id) return;
+        const eventDate = resolveEventDate(request);
+        const eventTimestamp = eventDate.getTime();
+
+        if (eventTimestamp <= driverCutoff) return;
+
+        if (request.status === "pending" && request.lastActionBy === "passenger") {
+          entries.push(createDriverPendingNotification(request));
+        }
+
+        if (request.status === "rejected" && request.lastActionBy === "passenger") {
+          entries.push(createDriverCancellationNotification(request));
+        }
+      });
+
+      if (entries.length) {
+        pushNotifications(entries);
+      }
+    },
+    [pushNotifications, user?.uid],
+  );
+
+  const processPassengerRequests = useCallback(
+    (requests: RideRequest[]) => {
+      if (!user?.uid) return;
+
+      const passengerCutoff = passengerLastSeenRef.current;
+      const entries: NotificationEntry[] = [];
+
+      requests.forEach((request) => {
+        if (!request.id) return;
+        const eventDate = resolveEventDate(request);
+        const eventTimestamp = eventDate.getTime();
+
+        if (eventTimestamp <= passengerCutoff) return;
+
+        if (request.status === "countered" && request.lastActionBy === "driver") {
+          entries.push(createPassengerCounterOfferNotification(request));
+        }
+
+        if (request.status === "rejected" && request.lastActionBy === "driver") {
+          entries.push(createPassengerRejectionNotification(request));
+        }
+      });
+
+      if (entries.length) {
+        pushNotifications(entries);
+      }
+    },
+    [pushNotifications, user?.uid],
+  );
+
+  useEffect(() => {
+    if (!user?.uid || !isReady) return;
+
+    const unsubscribeDriver = subscribeToDriverRequests(
+      user.uid,
+      processDriverRequests,
+    );
+
+    const unsubscribePassenger = subscribeToPassengerRequests(
+      user.uid,
+      processPassengerRequests,
+    );
+
+    return () => {
+      unsubscribeDriver?.();
+      unsubscribePassenger?.();
+    };
+  }, [user?.uid, isReady, processDriverRequests, processPassengerRequests]);
+
+  const markAllAsRead = useCallback(() => {
+    if (!user?.uid) return;
+    if (!notificationsRef.current.length) return;
+
+    let driverLatest = driverLastSeenRef.current;
+    let passengerLatest = passengerLastSeenRef.current;
+
+    const updated = notificationsRef.current.map((notification) => {
+      if (!notification.read) {
+        if (notification.source === "driver") {
+          driverLatest = Math.max(
+            driverLatest,
+            notification.createdAt.getTime(),
+          );
+        }
+
+        if (notification.source === "passenger") {
+          passengerLatest = Math.max(
+            passengerLatest,
+            notification.createdAt.getTime(),
+          );
+        }
+
+        return { ...notification, read: true };
+      }
+
+      return notification;
+    });
+
+    notificationsRef.current = updated;
+    setNotifications(updated);
+
+    if (driverLatest !== driverLastSeenRef.current) {
+      driverLastSeenRef.current = driverLatest;
+      persistLastSeen(user.uid, "driver", driverLatest);
+    }
+
+    if (passengerLatest !== passengerLastSeenRef.current) {
+      passengerLastSeenRef.current = passengerLatest;
+      persistLastSeen(user.uid, "passenger", passengerLatest);
+    }
+  }, [user?.uid]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => !notification.read).length,
+    [notifications],
+  );
+
+  const value = useMemo(
+    () => ({
+      notifications,
+      unreadCount,
+      markAllAsRead,
+    }),
+    [notifications, unreadCount, markAllAsRead],
+  );
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications() {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error(
+      "useNotifications debe usarse dentro de un NotificationProvider",
+    );
+  }
+  return context;
+}

--- a/src/lib/firestore-rides.ts
+++ b/src/lib/firestore-rides.ts
@@ -179,6 +179,8 @@ export async function requestRide(input: RequestRideInput) {
       finalPrice: null,
       requestKey,
       status: "pending",
+      statusUpdatedAt: serverTimestamp(),
+      lastActionBy: "passenger",
       createdAt: serverTimestamp(),
     });
 
@@ -199,6 +201,7 @@ export async function acceptRideRequest(
   requestId: string,
   rideId: string,
   acceptedPrice: number,
+  actor: "driver" | "passenger" = "driver",
 ) {
   const finalPriceValue = Number(acceptedPrice);
   if (!Number.isFinite(finalPriceValue) || finalPriceValue <= 0) {
@@ -247,6 +250,7 @@ export async function acceptRideRequest(
         status: "accepted",
         finalPrice: finalPriceValue,
         statusUpdatedAt: serverTimestamp(),
+        lastActionBy: actor,
       });
     });
 
@@ -267,7 +271,11 @@ export async function acceptRideRequest(
   }
 }
 
-export async function rejectRideRequest(requestId: string, rideId: string) {
+export async function rejectRideRequest(
+  requestId: string,
+  rideId: string,
+  actor: "driver" | "passenger",
+) {
   try {
     const requestRef = doc(db, REQUESTS_COLLECTION, requestId);
     const rideRef = doc(db, RIDES_COLLECTION, rideId);
@@ -300,6 +308,7 @@ export async function rejectRideRequest(requestId: string, rideId: string) {
         status: "rejected",
         statusUpdatedAt: serverTimestamp(),
         finalPrice: null,
+        lastActionBy: actor,
       });
     });
 
@@ -355,6 +364,7 @@ export async function counterOfferRideRequest(
         counterOfferPrice: counterValue,
         finalPrice: null,
         statusUpdatedAt: serverTimestamp(),
+        lastActionBy: "driver",
       });
     });
 
@@ -417,6 +427,7 @@ export async function updateRideRequestOffer(
         counterOfferPrice: null,
         finalPrice: null,
         statusUpdatedAt: serverTimestamp(),
+        lastActionBy: "passenger",
       });
     });
 
@@ -561,6 +572,10 @@ function mapRideRequestSnapshot(
     createdAt: toDate(data.createdAt),
     statusUpdatedAt: toDate(data.statusUpdatedAt),
     requestKey: data.requestKey,
+    lastActionBy:
+      data.lastActionBy === "driver" || data.lastActionBy === "passenger"
+        ? data.lastActionBy
+        : undefined,
   } as RideRequest;
 }
 

--- a/src/lib/firestore-rides.ts
+++ b/src/lib/firestore-rides.ts
@@ -21,7 +21,7 @@ import {
   type QueryDocumentSnapshot,
 } from "firebase/firestore";
 import { db } from "@/config/firebase";
-import type { Ride, RideRequest } from "@/types";
+import type { Ride, RideRequest, RideRequestStatus } from "@/types";
 
 const RIDES_COLLECTION = "rides";
 const REQUESTS_COLLECTION = "rideRequests";
@@ -133,6 +133,7 @@ export type RequestRideInput = {
   date: string;
   time: string;
   price: number;
+  offeredPrice: number;
 };
 
 export async function requestRide(input: RequestRideInput) {
@@ -173,6 +174,9 @@ export async function requestRide(input: RequestRideInput) {
       ...input,
       driverName: rideData.driverName ?? input.driverName,
       price: Number(input.price),
+      offeredPrice: Number(input.offeredPrice),
+      counterOfferPrice: null,
+      finalPrice: null,
       requestKey,
       status: "pending",
       createdAt: serverTimestamp(),
@@ -191,11 +195,19 @@ export async function requestRide(input: RequestRideInput) {
   }
 }
 
-export async function updateRideRequestStatus(
+export async function acceptRideRequest(
   requestId: string,
   rideId: string,
-  newStatus: "accepted" | "rejected",
+  acceptedPrice: number,
 ) {
+  const finalPriceValue = Number(acceptedPrice);
+  if (!Number.isFinite(finalPriceValue) || finalPriceValue <= 0) {
+    return {
+      success: false as const,
+      message: "Ingresá un precio válido para aceptar la solicitud.",
+    };
+  }
+
   try {
     const requestRef = doc(db, REQUESTS_COLLECTION, requestId);
     const rideRef = doc(db, RIDES_COLLECTION, rideId);
@@ -212,30 +224,28 @@ export async function updateRideRequestStatus(
       }
 
       const requestData = requestSnap.data() as DocumentData;
-      const currentStatus = requestData.status as RideRequest["status"];
+      const rideData = rideSnap.data() as DocumentData;
+      const currentStatus = (requestData.status ?? "pending") as RideRequestStatus;
 
-      if (currentStatus === newStatus) {
-        return;
+      if (currentStatus === "rejected") {
+        throw new Error("No se puede aceptar una solicitud rechazada.");
       }
 
-      if (currentStatus === "accepted" && newStatus !== "accepted") {
-        transaction.update(rideRef, {
-          availableSeats: increment(1),
-        });
-      } else if (currentStatus !== "accepted" && newStatus === "accepted") {
-        const rideData = rideSnap.data() as DocumentData;
+      if (currentStatus !== "accepted") {
         if ((rideData.availableSeats ?? 0) <= 0) {
           throw new Error(
             "No hay lugares disponibles para aceptar esta solicitud.",
           );
         }
+
         transaction.update(rideRef, {
           availableSeats: increment(-1),
         });
       }
 
       transaction.update(requestRef, {
-        status: newStatus,
+        status: "accepted",
+        finalPrice: finalPriceValue,
         statusUpdatedAt: serverTimestamp(),
       });
     });
@@ -246,13 +256,183 @@ export async function updateRideRequestStatus(
       updatedRequest: mapRideRequestSnapshot(updatedSnapshot),
     };
   } catch (error) {
-    console.error("Error al actualizar el estado de la solicitud", error);
+    console.error("Error al aceptar la solicitud", error);
     return {
       success: false as const,
       message:
         error instanceof Error
           ? error.message
-          : "No se pudo actualizar la solicitud.",
+          : "No se pudo aceptar la solicitud.",
+    };
+  }
+}
+
+export async function rejectRideRequest(requestId: string, rideId: string) {
+  try {
+    const requestRef = doc(db, REQUESTS_COLLECTION, requestId);
+    const rideRef = doc(db, RIDES_COLLECTION, rideId);
+
+    await runTransaction(db, async (transaction) => {
+      const requestSnap = await transaction.get(requestRef);
+      if (!requestSnap.exists()) {
+        throw new Error("La solicitud no existe.");
+      }
+
+      const rideSnap = await transaction.get(rideRef);
+      if (!rideSnap.exists()) {
+        throw new Error("El viaje no existe.");
+      }
+
+      const requestData = requestSnap.data() as DocumentData;
+      const currentStatus = (requestData.status ?? "pending") as RideRequestStatus;
+
+      if (currentStatus === "rejected") {
+        return;
+      }
+
+      if (currentStatus === "accepted") {
+        transaction.update(rideRef, {
+          availableSeats: increment(1),
+        });
+      }
+
+      transaction.update(requestRef, {
+        status: "rejected",
+        statusUpdatedAt: serverTimestamp(),
+        finalPrice: null,
+      });
+    });
+
+    const updatedSnapshot = await getDoc(requestRef);
+    return {
+      success: true as const,
+      updatedRequest: mapRideRequestSnapshot(updatedSnapshot),
+    };
+  } catch (error) {
+    console.error("Error al rechazar la solicitud", error);
+    return {
+      success: false as const,
+      message:
+        error instanceof Error
+          ? error.message
+          : "No se pudo rechazar la solicitud.",
+    };
+  }
+}
+
+export async function counterOfferRideRequest(
+  requestId: string,
+  counterOfferPrice: number,
+) {
+  const counterValue = Number(counterOfferPrice);
+  if (!Number.isFinite(counterValue) || counterValue <= 0) {
+    return {
+      success: false as const,
+      message: "Ingresá un valor válido para la contraoferta.",
+    };
+  }
+
+  try {
+    const requestRef = doc(db, REQUESTS_COLLECTION, requestId);
+
+    await runTransaction(db, async (transaction) => {
+      const requestSnap = await transaction.get(requestRef);
+      if (!requestSnap.exists()) {
+        throw new Error("La solicitud no existe.");
+      }
+
+      const requestData = requestSnap.data() as DocumentData;
+      const currentStatus = (requestData.status ?? "pending") as RideRequestStatus;
+
+      if (currentStatus === "accepted") {
+        throw new Error(
+          "La solicitud ya fue aceptada, no se puede contraofertar.",
+        );
+      }
+
+      transaction.update(requestRef, {
+        status: "countered",
+        counterOfferPrice: counterValue,
+        finalPrice: null,
+        statusUpdatedAt: serverTimestamp(),
+      });
+    });
+
+    const updatedSnapshot = await getDoc(requestRef);
+    return {
+      success: true as const,
+      updatedRequest: mapRideRequestSnapshot(updatedSnapshot),
+    };
+  } catch (error) {
+    console.error("Error al contraofertar la solicitud", error);
+    return {
+      success: false as const,
+      message:
+        error instanceof Error
+          ? error.message
+          : "No se pudo enviar la contraoferta.",
+    };
+  }
+}
+
+export async function updateRideRequestOffer(
+  requestId: string,
+  offeredPrice: number,
+) {
+  const offerValue = Number(offeredPrice);
+  if (!Number.isFinite(offerValue) || offerValue <= 0) {
+    return {
+      success: false as const,
+      message: "Ingresá un valor válido para la oferta.",
+    };
+  }
+
+  try {
+    const requestRef = doc(db, REQUESTS_COLLECTION, requestId);
+
+    await runTransaction(db, async (transaction) => {
+      const requestSnap = await transaction.get(requestRef);
+      if (!requestSnap.exists()) {
+        throw new Error("La solicitud no existe.");
+      }
+
+      const requestData = requestSnap.data() as DocumentData;
+      const currentStatus = (requestData.status ?? "pending") as RideRequestStatus;
+
+      if (currentStatus === "accepted") {
+        throw new Error(
+          "El viaje ya fue aceptado, no es posible modificar la oferta.",
+        );
+      }
+
+      if (currentStatus === "rejected") {
+        throw new Error(
+          "La solicitud fue rechazada. Generá una nueva solicitud para negociar de nuevo.",
+        );
+      }
+
+      transaction.update(requestRef, {
+        status: "pending",
+        offeredPrice: offerValue,
+        counterOfferPrice: null,
+        finalPrice: null,
+        statusUpdatedAt: serverTimestamp(),
+      });
+    });
+
+    const updatedSnapshot = await getDoc(requestRef);
+    return {
+      success: true as const,
+      updatedRequest: mapRideRequestSnapshot(updatedSnapshot),
+    };
+  } catch (error) {
+    console.error("Error al actualizar la oferta", error);
+    return {
+      success: false as const,
+      message:
+        error instanceof Error
+          ? error.message
+          : "No se pudo actualizar la oferta.",
     };
   }
 }
@@ -356,12 +536,28 @@ function mapRideRequestSnapshot(
     passengerUid: data.passengerUid,
     passengerName: data.passengerName,
     driverUid: data.driverUid,
-    status: data.status,
+    status: (data.status as RideRequestStatus) ?? "pending",
     origin: data.origin,
     destination: data.destination,
     date: data.date,
     time: data.time,
     price: typeof data.price === "number" ? data.price : Number(data.price ?? 0),
+    offeredPrice:
+      typeof data.offeredPrice === "number"
+        ? data.offeredPrice
+        : Number(data.offeredPrice ?? data.price ?? 0),
+    counterOfferPrice:
+      typeof data.counterOfferPrice === "number"
+        ? data.counterOfferPrice
+        : data.counterOfferPrice === null || data.counterOfferPrice === undefined
+          ? null
+          : Number(data.counterOfferPrice),
+    finalPrice:
+      typeof data.finalPrice === "number"
+        ? data.finalPrice
+        : data.finalPrice === null || data.finalPrice === undefined
+          ? null
+          : Number(data.finalPrice),
     createdAt: toDate(data.createdAt),
     statusUpdatedAt: toDate(data.statusUpdatedAt),
     requestKey: data.requestKey,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,4 +46,5 @@ export type RideRequest = {
   createdAt?: Date; // Marca de tiempo de creación
   statusUpdatedAt?: Date; // Marca de tiempo de última actualización
   requestKey?: string; // Clave única compuesta para validaciones
+  lastActionBy?: "driver" | "passenger"; // Quién realizó la última acción relevante
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,8 @@ export type Ride = {
   createdAt?: Date; // Marca de tiempo de creación (opcional)
 };
 
+export type RideRequestStatus = 'pending' | 'countered' | 'accepted' | 'rejected';
+
 // Tipo para las solicitudes de viaje
 export type RideRequest = {
   id?: string; // ID del documento en Firestore
@@ -32,12 +34,15 @@ export type RideRequest = {
   passengerUid: string; // UID del pasajero
   passengerName: string; // Nombre del pasajero
   driverUid: string; // UID del conductor (para notificaciones o consultas)
-  status: 'pending' | 'accepted' | 'rejected'; // Estado de la solicitud
+  status: RideRequestStatus; // Estado de la solicitud
   origin?: string; // Origen (desnormalizado)
   destination?: string; // Destino (desnormalizado)
   date?: string; // Fecha (desnormalizado)
   time?: string; // Hora (desnormalizado)
   price?: number; // Precio por lugar (desnormalizado)
+  offeredPrice?: number; // Precio ofertado por el pasajero
+  counterOfferPrice?: number | null; // Contraoferta del conductor, si existe
+  finalPrice?: number | null; // Precio final acordado cuando el viaje es aceptado
   createdAt?: Date; // Marca de tiempo de creación
   statusUpdatedAt?: Date; // Marca de tiempo de última actualización
   requestKey?: string; // Clave única compuesta para validaciones


### PR DESCRIPTION
## Summary
- extend ride request schema and Firestore helpers to capture passenger offers, driver counter offers, and accepted prices
- require passengers to propose an offer when requesting a ride and expose controls to edit offers or accept driver counter offers
- update driver dashboard cards to review offers, send counter offers, and track negotiation status with seat accounting

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd550f5fd083308d32ae6e30356a92