### PR TITLE
feat: persist driver notifications until opened

### DIFF
--- a/src/app/dashboard/conductor/page.tsx
+++ b/src/app/dashboard/conductor/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { format, formatDistanceToNow } from "date-fns";
 import { es } from "date-fns/locale";
 import { Loader2, PlusCircle } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 
 import { AppLayout } from "@/components/layout/app-layout";
 import { DriverRideCard } from "@/components/dashboard/driver-ride-card";
@@ -15,7 +16,11 @@ import {
   subscribeToDriverRides,
   subscribeToDriverRequests,
 } from "@/lib/firestore-rides";
-import { useNotifications } from "@/contexts/notification-provider";
+import {
+  useNotifications,
+  type NotificationEntry,
+} from "@/contexts/notification-provider";
+import { cn } from "@/lib/utils";
 
 type RideFilter = "all" | "pending" | "countered" | "accepted" | "no-requests";
 
@@ -44,7 +49,13 @@ export default function DriverDashboardPage() {
   const [rideRequests, setRideRequests] = useState<RideRequest[]>([]);
   const [isFetching, setIsFetching] = useState(true);
   const [selectedFilter, setSelectedFilter] = useState<RideFilter>("all");
-  const { notifications, markAllAsRead } = useNotifications();
+  const searchParams = useSearchParams();
+  const { notifications, markAllAsRead, markAsRead } = useNotifications();
+  const [highlightedNotificationId, setHighlightedNotificationId] = useState<string | null>(
+    null,
+  );
+  const [highlightedRequestId, setHighlightedRequestId] = useState<string | null>(null);
+  const notificationsSectionRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!user?.uid) {
@@ -78,6 +89,67 @@ export default function DriverDashboardPage() {
       unsubscribeRequests();
     };
   }, [user?.uid, user?.displayName, user?.email]);
+
+  useEffect(() => {
+    const notificationParam = searchParams.get("notificacion");
+    const requestParam = searchParams.get("solicitud");
+
+    setHighlightedNotificationId(notificationParam);
+    setHighlightedRequestId(requestParam);
+
+    if ((notificationParam || requestParam) && typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      if (notificationParam) {
+        url.searchParams.delete("notificacion");
+      }
+      if (requestParam) {
+        url.searchParams.delete("solicitud");
+      }
+      window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!highlightedRequestId) return;
+
+    const targetRequest = rideRequests.find(
+      (request) => request.id === highlightedRequestId,
+    );
+    if (!targetRequest) return;
+
+    if (targetRequest.status === "pending" && selectedFilter !== "pending") {
+      setSelectedFilter("pending");
+    }
+
+    if (targetRequest.status === "countered" && selectedFilter !== "countered") {
+      setSelectedFilter("countered");
+    }
+
+    if (targetRequest.status === "accepted" && selectedFilter !== "accepted") {
+      setSelectedFilter("accepted");
+    }
+
+    if (typeof window === "undefined") return;
+
+    const timer = window.setTimeout(() => {
+      if (targetRequest.rideId) {
+        const rideElement = document.getElementById(`ride-${targetRequest.rideId}`);
+        if (rideElement) {
+          rideElement.scrollIntoView({ behavior: "smooth", block: "start" });
+          return;
+        }
+      }
+
+      notificationsSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }, 200);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [highlightedRequestId, rideRequests, selectedFilter]);
 
   const ridesWithRequests = useMemo<RideWithRequests[]>(() => {
     const requestsByRide = rideRequests.reduce<Record<string, RideRequest[]>>(
@@ -211,6 +283,38 @@ export default function DriverDashboardPage() {
     () => driverNotifications.filter((notification) => !notification.read).length,
     [driverNotifications],
   );
+
+  useEffect(() => {
+    if (!highlightedNotificationId) return;
+
+    const targetNotification = driverNotifications.find(
+      (notification) => notification.id === highlightedNotificationId,
+    );
+
+    if (targetNotification && !targetNotification.read) {
+      markAsRead(targetNotification.id);
+    }
+  }, [driverNotifications, highlightedNotificationId, markAsRead]);
+
+  const handleNotificationCardClick = (notification: NotificationEntry) => {
+    markAsRead(notification.id);
+    setHighlightedNotificationId(notification.id);
+
+    if (notification.requestId) {
+      setHighlightedRequestId(notification.requestId);
+    } else {
+      setHighlightedRequestId(null);
+    }
+
+    if (typeof window !== "undefined") {
+      window.setTimeout(() => {
+        notificationsSectionRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }, 100);
+    }
+  };
 
   const lastUpdatedText = driverStats.latestActivity
     ? formatDistanceToNow(driverStats.latestActivity, { addSuffix: true, locale: es })
@@ -401,9 +505,21 @@ export default function DriverDashboardPage() {
             </div>
           ) : filteredRides.length > 0 ? (
             <div className="space-y-4">
-              {filteredRides.map(({ ride, requests }) => (
-                <DriverRideCard key={ride.id} ride={ride} requests={requests} />
-              ))}
+              {filteredRides.map(({ ride, requests }) => {
+                const shouldHighlightRequest =
+                  highlightedRequestId &&
+                  requests.some((request) => request.id === highlightedRequestId);
+
+                return (
+                  <DriverRideCard
+                    key={ride.id}
+                    ride={ride}
+                    requests={requests}
+                    highlightedRequestId={shouldHighlightRequest ? highlightedRequestId : null}
+                    isHighlighted={Boolean(shouldHighlightRequest)}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div className="rounded-lg border border-dashed p-8 text-center">
@@ -430,7 +546,10 @@ export default function DriverDashboardPage() {
           )}
         </section>
 
-        <section className="space-y-4 rounded-lg border p-4">
+        <section
+          ref={notificationsSectionRef}
+          className="space-y-4 rounded-lg border p-4"
+        >
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="space-y-1">
               <h2 className="text-lg font-semibold">Notificaciones</h2>
@@ -447,7 +566,11 @@ export default function DriverDashboardPage() {
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={markAllAsRead}
+                onClick={() => {
+                  markAllAsRead();
+                  setHighlightedNotificationId(null);
+                  setHighlightedRequestId(null);
+                }}
                 disabled={driverNotifications.length === 0 || driverUnread === 0}
               >
                 Marcar como leídas
@@ -460,29 +583,48 @@ export default function DriverDashboardPage() {
             </p>
           ) : (
             <div className="space-y-3">
-              {driverNotifications.slice(0, 6).map((notification) => (
-                <div
-                  key={notification.id}
-                  className="space-y-1 rounded-md border border-border/60 p-3"
-                >
-                  <p
-                    className={`text-sm font-medium ${
-                      notification.read ? "text-muted-foreground" : "text-foreground"
-                    }`}
+              {driverNotifications.slice(0, 6).map((notification) => {
+                const isHighlighted =
+                  highlightedNotificationId === notification.id ||
+                  (highlightedRequestId &&
+                    notification.requestId &&
+                    highlightedRequestId === notification.requestId);
+
+                return (
+                  <button
+                    key={notification.id}
+                    type="button"
+                    onClick={() => handleNotificationCardClick(notification)}
+                    className={cn(
+                      "w-full space-y-1 rounded-md border border-border/60 p-3 text-left transition-colors",
+                      notification.read
+                        ? "bg-background hover:border-border"
+                        : "bg-muted/60 hover:bg-muted",
+                      isHighlighted && "border-primary/80 ring-2 ring-primary/40",
+                    )}
                   >
-                    {notification.title}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {notification.description}
-                  </p>
-                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                    {formatDistanceToNow(notification.createdAt, {
-                      addSuffix: true,
-                      locale: es,
-                    })}
-                  </p>
-                </div>
-              ))}
+                    <p
+                      className={cn(
+                        "text-sm font-medium",
+                        notification.read
+                          ? "text-muted-foreground"
+                          : "text-foreground",
+                      )}
+                    >
+                      {notification.title}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {notification.description}
+                    </p>
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                      {formatDistanceToNow(notification.createdAt, {
+                        addSuffix: true,
+                        locale: es,
+                      })}
+                    </p>
+                  </button>
+                );
+              })}
             </div>
           )}
         </section>

--- a/src/components/dashboard/driver-ride-card.tsx
+++ b/src/components/dashboard/driver-ride-card.tsx
@@ -84,11 +84,15 @@ import { format, isValid, parseISO } from "date-fns";
 interface DriverRideCardProps {
   ride: Ride;
   requests: RideRequest[]; // Solicitudes específicas para este viaje
+  highlightedRequestId?: string | null;
+  isHighlighted?: boolean;
 }
 
 export function DriverRideCard({
   ride,
   requests: initialRequests,
+  highlightedRequestId = null,
+  isHighlighted = false,
 }: DriverRideCardProps) {
   const { toast } = useToast();
   const [requests, setRequests] = useState<RideRequest[]>(initialRequests);
@@ -104,6 +108,7 @@ export function DriverRideCard({
   );
   const [counterOfferValue, setCounterOfferValue] = useState<string>("");
   const [isSendingCounterOffer, setIsSendingCounterOffer] = useState(false);
+  const [accordionValue, setAccordionValue] = useState<string | undefined>();
 
   const form = useForm<RideFormValues>({
     resolver: zodResolver(rideFormSchema),
@@ -117,6 +122,12 @@ export function DriverRideCard({
   useEffect(() => {
     form.reset(mapRideToFormValues(ride));
   }, [ride, form]);
+
+  useEffect(() => {
+    if (!highlightedRequestId) return;
+    if (!requests.some((request) => request.id === highlightedRequestId)) return;
+    setAccordionValue("requests");
+  }, [highlightedRequestId, requests]);
 
   const activeRequests = useMemo(
     () =>
@@ -358,7 +369,13 @@ export function DriverRideCard({
   };
 
   return (
-    <Card className="w-full shadow-lg">
+    <Card
+      id={ride.id ? `ride-${ride.id}` : undefined}
+      className={cn(
+        "w-full shadow-lg transition-shadow",
+        isHighlighted && "border-primary/80 ring-2 ring-primary/40",
+      )}
+    >
       <CardHeader>
         <CardTitle className="text-xl flex justify-between items-center">
           <span>
@@ -376,7 +393,15 @@ export function DriverRideCard({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <Accordion type="single" collapsible className="w-full">
+        <Accordion
+          type="single"
+          collapsible
+          className="w-full"
+          value={accordionValue}
+          onValueChange={(value) =>
+            setAccordionValue(value === "" ? undefined : value)
+          }
+        >
           <AccordionItem value="requests">
             <AccordionTrigger>
               Ver Solicitudes ({activeRequests.length} en curso,{' '}
@@ -390,6 +415,8 @@ export function DriverRideCard({
               ) : (
                 <div className="space-y-4 pt-2">
                   {requests.map((request) => {
+                    const isHighlightedRequest =
+                      highlightedRequestId === request.id;
                     const passengerOffer =
                       typeof request.offeredPrice === "number"
                         ? request.offeredPrice
@@ -408,7 +435,12 @@ export function DriverRideCard({
                     return (
                       <div
                         key={request.id}
-                        className="p-3 border rounded-md bg-background/50"
+                        data-request-id={request.id}
+                        className={cn(
+                          "p-3 border rounded-md bg-background/50 transition-shadow",
+                          isHighlightedRequest &&
+                            "border-primary/80 ring-2 ring-primary/40 bg-primary/5",
+                        )}
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -33,8 +33,11 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { useNotifications } from '@/contexts/notification-provider';
-import type { NotificationType } from '@/contexts/notification-provider';
+import {
+  useNotifications,
+  type NotificationEntry,
+  type NotificationType,
+} from '@/contexts/notification-provider';
 import { cn } from '@/lib/utils';
 
 const notificationIcons: Record<NotificationType, { Icon: LucideIcon; className: string }> = {
@@ -46,15 +49,43 @@ const notificationIcons: Record<NotificationType, { Icon: LucideIcon; className:
 export function Navbar() {
   const { user } = useAuth();
   const router = useRouter();
-  const { notifications, unreadCount, markAllAsRead } = useNotifications();
+  const { notifications, unreadCount, markAsRead } = useNotifications();
   const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
   const latestNotifications = notifications.slice(0, 10);
 
   const handleNotificationsOpenChange = (open: boolean) => {
     setIsNotificationsOpen(open);
-    if (open) {
-      markAllAsRead();
+  };
+
+  const buildNotificationUrl = (notification: NotificationEntry) => {
+    const params = new URLSearchParams();
+    params.set('notificacion', notification.id);
+    if (notification.requestId) {
+      params.set('solicitud', notification.requestId);
     }
+    if (notification.rideId) {
+      params.set('viaje', notification.rideId);
+    }
+
+    const queryString = params.toString();
+
+    if (notification.source === 'driver') {
+      return `/dashboard/conductor${queryString ? `?${queryString}` : ''}`;
+    }
+
+    if (notification.source === 'passenger') {
+      return `/dashboard/pasajero${queryString ? `?${queryString}` : ''}`;
+    }
+
+    return '/';
+  };
+
+  const handleNotificationClick = (notification: NotificationEntry) => {
+    markAsRead(notification.id);
+    setIsNotificationsOpen(false);
+
+    const targetUrl = buildNotificationUrl(notification);
+    router.push(targetUrl);
   };
 
   const handleLogout = async () => {
@@ -150,10 +181,12 @@ export function Navbar() {
                           );
 
                           return (
-                            <div
+                            <button
                               key={notification.id}
+                              type="button"
+                              onClick={() => handleNotificationClick(notification)}
                               className={cn(
-                                "flex items-start gap-3 px-4 py-3 text-sm transition-colors",
+                                "flex w-full items-start gap-3 px-4 py-3 text-left text-sm transition-colors",
                                 notification.read
                                   ? "hover:bg-muted/60"
                                   : "bg-muted/60 hover:bg-muted",
@@ -187,7 +220,7 @@ export function Navbar() {
                                   {relativeTime}
                                 </p>
                               </div>
-                            </div>
+                            </button>
                           );
                         })}
                       </div>

--- a/src/contexts/notification-provider.tsx
+++ b/src/contexts/notification-provider.tsx
@@ -20,6 +20,7 @@ import { useToast } from "@/hooks/use-toast";
 
 const MAX_NOTIFICATIONS = 30;
 const LAST_SEEN_STORAGE_KEY = "rc:last-seen";
+const LAST_SEEN_FALLBACK = 0;
 
 export type NotificationType = "new-request" | "counter-offer" | "rejection";
 export type NotificationSource = "driver" | "passenger";
@@ -83,13 +84,13 @@ function buildNotificationId(
 }
 
 function loadLastSeen(uid: string, role: NotificationSource) {
-  if (typeof window === "undefined") return Date.now();
+  if (typeof window === "undefined") return LAST_SEEN_FALLBACK;
   const stored = window.localStorage.getItem(
     `${LAST_SEEN_STORAGE_KEY}:${uid}:${role}`,
   );
-  if (!stored) return Date.now();
+  if (!stored) return LAST_SEEN_FALLBACK;
   const parsed = Number(stored);
-  return Number.isFinite(parsed) ? parsed : Date.now();
+  return Number.isFinite(parsed) ? parsed : LAST_SEEN_FALLBACK;
 }
 
 function persistLastSeen(uid: string, role: NotificationSource, value: number) {

--- a/src/contexts/notification-provider.tsx
+++ b/src/contexts/notification-provider.tsx
@@ -40,6 +40,7 @@ interface NotificationContextValue {
   notifications: NotificationEntry[];
   unreadCount: number;
   markAllAsRead: () => void;
+  markAsRead: (notificationId: string) => void;
 }
 
 const NotificationContext =
@@ -138,16 +139,17 @@ function createDriverPendingNotification(request: RideRequest): NotificationEntr
       ? `para el viaje de ${request.origin} a ${request.destination}`
       : "para tu viaje";
   const price = formatCurrency(request.offeredPrice ?? request.price ?? null);
+  const type: NotificationType = isUpdatedOffer ? "counter-offer" : "new-request";
 
   return {
-    id: buildNotificationId(request, "new-request", timestamp),
-    type: "new-request",
+    id: buildNotificationId(request, type, timestamp),
+    type,
     source: "driver",
     title: isUpdatedOffer
-      ? "El pasajero actualizó su oferta"
+      ? "Nueva contraoferta del pasajero"
       : "Nueva solicitud de viaje",
     description: isUpdatedOffer
-      ? `${passengerName} propuso ${price} ${route}.`
+      ? `${passengerName} envió una contraoferta de ${price} ${route}.`
       : `${passengerName} solicitó un lugar ${route} por ${price}.`,
     createdAt: eventDate,
     read: false,
@@ -424,6 +426,46 @@ export function NotificationProvider({
     }
   }, [user?.uid]);
 
+  const markAsRead = useCallback(
+    (notificationId: string) => {
+      if (!user?.uid) return;
+      if (!notificationId) return;
+
+      const existing = notificationsRef.current;
+      if (!existing.length) return;
+
+      const target = existing.find((notification) => notification.id === notificationId);
+      if (!target) return;
+      if (target.read) return;
+
+      const updated = existing.map((notification) =>
+        notification.id === notificationId
+          ? { ...notification, read: true }
+          : notification,
+      );
+
+      notificationsRef.current = updated;
+      setNotifications(updated);
+
+      const createdTimestamp = target.createdAt.getTime();
+
+      if (target.source === "driver") {
+        if (createdTimestamp > driverLastSeenRef.current) {
+          driverLastSeenRef.current = createdTimestamp;
+          persistLastSeen(user.uid, "driver", createdTimestamp);
+        }
+      }
+
+      if (target.source === "passenger") {
+        if (createdTimestamp > passengerLastSeenRef.current) {
+          passengerLastSeenRef.current = createdTimestamp;
+          persistLastSeen(user.uid, "passenger", createdTimestamp);
+        }
+      }
+    },
+    [user?.uid],
+  );
+
   const unreadCount = useMemo(
     () => notifications.filter((notification) => !notification.read).length,
     [notifications],
@@ -434,8 +476,9 @@ export function NotificationProvider({
       notifications,
       unreadCount,
       markAllAsRead,
+      markAsRead,
     }),
-    [notifications, unreadCount, markAllAsRead],
+    [notifications, unreadCount, markAllAsRead, markAsRead],
   );
 
   return (


### PR DESCRIPTION
## Summary
- add granular read tracking for notifications and emit counter-offer alerts when passengers update an offer
- make driver notifications navigable from the navbar and highlight the targeted ride/request when opened
- refresh driver dashboard notifications so entries stay unread until opened and can be marked individually

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd7387be988330a2e4d17b49e8b156