### PR TITLE
Ajusta el manejo local de fechas en formularios y tarjetas

### DIFF
--- a/src/components/dashboard/driver-ride-card.tsx
+++ b/src/components/dashboard/driver-ride-card.tsx
@@ -70,6 +70,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { toLocalDate } from "@/lib/date";
 import {
   acceptRideRequest,
   counterOfferRideRequest,
@@ -79,7 +80,8 @@ import {
 } from "@/lib/firestore-rides";
 import { rideFormSchema, type RideFormValues } from "@/lib/validators/ride";
 import { useToast } from "@/hooks/use-toast";
-import { format, isValid, parseISO } from "date-fns";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
 
 interface DriverRideCardProps {
   ride: Ride;
@@ -143,8 +145,8 @@ export function DriverRideCard({
   const acceptedRequestCount = acceptedRequests.length;
 
   const formattedDate = useMemo(() => {
-    const parsed = ride.date ? parseISO(ride.date) : null;
-    return parsed && isValid(parsed) ? format(parsed, "PPP") : ride.date;
+    const parsed = ride.date ? toLocalDate(ride.date) : null;
+    return parsed ? format(parsed, "PPP", { locale: es }) : ride.date;
   }, [ride.date]);
 
   const updateRequestState = (updatedRequest: RideRequest) => {
@@ -729,7 +731,7 @@ export function DriverRideCard({
                                 )}
                               >
                                 {field.value ? (
-                                  format(field.value, "PPP")
+                                  format(field.value, "PPP", { locale: es })
                                 ) : (
                                   <span>Seleccioná una fecha</span>
                                 )}
@@ -863,8 +865,8 @@ export function DriverRideCard({
 }
 
 function mapRideToFormValues(ride: Ride): RideFormValues {
-  const parsedDate = ride.date ? parseISO(ride.date) : undefined;
-  const safeDate = parsedDate && isValid(parsedDate) ? parsedDate : new Date();
+  const parsedDate = ride.date ? toLocalDate(ride.date) : null;
+  const safeDate = parsedDate ?? new Date();
 
   return {
     origin: ride.origin ?? "",

--- a/src/components/dashboard/passenger-request-card.tsx
+++ b/src/components/dashboard/passenger-request-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { RideRequest } from "@/types";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -27,6 +27,9 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { toLocalDate } from "@/lib/date";
 import {
   acceptRideRequest,
   rejectRideRequest,
@@ -46,6 +49,15 @@ export function PassengerRequestCard({ request }: PassengerRequestCardProps) {
   const [offerValue, setOfferValue] = useState(
     () => (request.offeredPrice ?? request.price ?? 0).toString(),
   );
+
+  const formattedRideDate = useMemo(() => {
+    if (!request.date) {
+      return "N/A";
+    }
+
+    const parsed = toLocalDate(request.date);
+    return parsed ? format(parsed, "PPP", { locale: es }) : request.date;
+  }, [request.date]);
 
   let statusColor: "default" | "secondary" | "destructive" | "outline" | null | undefined = "secondary";
   let StatusIcon = Loader2;
@@ -211,7 +223,7 @@ export function PassengerRequestCard({ request }: PassengerRequestCardProps) {
       <CardContent className="space-y-3">
         <div className="flex items-center text-sm text-muted-foreground">
           <CalendarDays className="mr-2 h-4 w-4 text-primary" />
-          <span>{request.date ? new Date(request.date).toLocaleDateString() : "N/A"}</span>
+          <span>{formattedRideDate}</span>
         </div>
         <div className="flex items-center text-sm text-muted-foreground">
           <Clock className="mr-2 h-4 w-4 text-primary" />

--- a/src/components/rides/ride-card.tsx
+++ b/src/components/rides/ride-card.tsx
@@ -24,8 +24,11 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/auth-provider";
 import { requestRide } from "@/lib/firestore-rides";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Loader2 } from "lucide-react";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { toLocalDate } from "@/lib/date";
 
 interface RideCardProps {
   ride: Ride;
@@ -37,6 +40,11 @@ export function RideCard({ ride }: RideCardProps) {
   const [isRequesting, setIsRequesting] = useState(false);
   const [isOfferDialogOpen, setIsOfferDialogOpen] = useState(false);
   const [offerValue, setOfferValue] = useState(() => ride.price.toString());
+
+  const formattedRideDate = useMemo(() => {
+    const parsedDate = toLocalDate(ride.date);
+    return parsedDate ? format(parsedDate, "PPP", { locale: es }) : ride.date;
+  }, [ride.date]);
 
   const handleOpenOfferDialog = () => {
     if (!user) {
@@ -123,7 +131,7 @@ export function RideCard({ ride }: RideCardProps) {
       <CardContent className="space-y-3">
         <div className="flex items-center text-sm text-muted-foreground">
           <CalendarDays className="mr-2 h-4 w-4 text-primary" />
-          <span>{new Date(ride.date).toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</span>
+          <span>{formattedRideDate}</span>
         </div>
         <div className="flex items-center text-sm text-muted-foreground">
           <Clock className="mr-2 h-4 w-4 text-primary" />

--- a/src/components/rides/search-rides-form.tsx
+++ b/src/components/rides/search-rides-form.tsx
@@ -23,7 +23,9 @@ import {
 } from "@/components/ui/popover";
 import { CalendarIcon, Loader2 } from "lucide-react";
 import { format } from "date-fns";
+import { es } from "date-fns/locale";
 import { cn } from "@/lib/utils";
+import { toLocalDate } from "@/lib/date";
 
 const searchRidesSchema = z.object({
   origin: z.string().min(1, "El origen es requerido."),
@@ -37,12 +39,15 @@ export function SearchRidesForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  const dateParam = searchParams.get("date");
+  const parsedDate = dateParam ? toLocalDate(dateParam) : null;
+
   const form = useForm<SearchRidesFormValues>({
     resolver: zodResolver(searchRidesSchema),
     defaultValues: {
-      origin: searchParams.get('origin') || "",
-      destination: searchParams.get('destination') || "",
-      date: searchParams.get('date') ? new Date(searchParams.get('date')!) : new Date(),
+      origin: searchParams.get("origin") || "",
+      destination: searchParams.get("destination") || "",
+      date: parsedDate ?? new Date(),
     },
   });
   const { formState: { isSubmitting } } = form;
@@ -103,7 +108,7 @@ export function SearchRidesForm() {
                         )}
                       >
                         {field.value ? (
-                          format(field.value, "PPP")
+                          format(field.value, "PPP", { locale: es })
                         ) : (
                           <span>Seleccioná una fecha</span>
                         )}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,43 @@
+/**
+ * Converts a YYYY-MM-DD string into a Date object at local midnight without
+ * applying UTC offsets that `Date.parse` would normally introduce.
+ *
+ * @param input - Date string in the format YYYY-MM-DD.
+ * @returns A Date instance at local midnight or null if the input is invalid.
+ */
+export function toLocalDate(input?: string | null): Date | null {
+  if (!input) {
+    return null;
+  }
+
+  const trimmed = input.trim();
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+
+  if ([year, month, day].some((value) => Number.isNaN(value))) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, day);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  // Ensure the produced date matches the provided components to avoid overflow.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}


### PR DESCRIPTION
## Summary
- agrega el helper `toLocalDate` para convertir cadenas YYYY-MM-DD en instancias de fecha locales a medianoche
- usa el helper en los formularios y tarjetas de viajes para inicializar y mostrar fechas con `date-fns` y locale `es`
- actualiza el panel de conductor para mapear y renderizar las fechas con el nuevo helper

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d29d231a2c8330a5ee86718139d151