### PR TITLE
feat: sort rides by local departure time

### DIFF
--- a/src/app/viajes/page.tsx
+++ b/src/app/viajes/page.tsx
@@ -11,6 +11,7 @@ import { AlertCircle, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { subscribeToAllRides } from "@/lib/firestore-rides";
+import { getLocalDepartureDate } from "@/lib/date";
 
 function RideListings() {
   const searchParams = useSearchParams();
@@ -46,9 +47,25 @@ function RideListings() {
         return matches;
       })
       .filter((ride) => ride.availableSeats > 0)
-      .sort(
-        (a, b) => (a.createdAt?.getTime() || 0) - (b.createdAt?.getTime() || 0),
-      );
+      .sort((a, b) => {
+        const departureA = getLocalDepartureDate(a)?.getTime() ?? null;
+        const departureB = getLocalDepartureDate(b)?.getTime() ?? null;
+
+        if (departureA !== departureB) {
+          if (departureA === null) {
+            return 1;
+          }
+          if (departureB === null) {
+            return -1;
+          }
+          return departureA - departureB;
+        }
+
+        const createdAtA = a.createdAt?.getTime() ?? 0;
+        const createdAtB = b.createdAt?.getTime() ?? 0;
+
+        return createdAtA - createdAtB;
+      });
   }, [rides, origin, destination, date]);
 
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -41,3 +41,76 @@ export function toLocalDate(input?: string | null): Date | null {
 
   return date;
 }
+
+/**
+ * Combines a YYYY-MM-DD string and an HH:MM(:SS) string into a Date instance
+ * using the local timezone without applying UTC offsets.
+ *
+ * @param dateInput - Date string in the format YYYY-MM-DD.
+ * @param timeInput - Time string in the format HH:MM or HH:MM:SS.
+ * @returns A Date instance representing the combined local date and time, or
+ * null if either value is invalid.
+ */
+export function toLocalDateTime(
+  dateInput?: string | null,
+  timeInput?: string | null,
+): Date | null {
+  const date = toLocalDate(dateInput);
+  if (!date || !timeInput) {
+    return null;
+  }
+
+  const trimmed = timeInput.trim();
+  const match = /^(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  const seconds = match[3] ? Number(match[3]) : 0;
+
+  if (
+    [hours, minutes, seconds].some((value) => Number.isNaN(value)) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59 ||
+    seconds < 0 ||
+    seconds > 59
+  ) {
+    return null;
+  }
+
+  const result = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    hours,
+    minutes,
+    seconds,
+    0,
+  );
+
+  if (Number.isNaN(result.getTime())) {
+    return null;
+  }
+
+  return result;
+}
+
+type DateTimeFields = {
+  date?: string | null;
+  time?: string | null;
+};
+
+/**
+ * Produces a local departure date for a ride-like object using its date and
+ * time fields.
+ */
+export function getLocalDepartureDate({
+  date,
+  time,
+}: DateTimeFields): Date | null {
+  return toLocalDateTime(date, time);
+}


### PR DESCRIPTION
## Summary
- add reusable helpers to convert ride date and time strings into reliable local Date objects
- update the ride listings page to order results by the computed departure timestamp with a createdAt tie-breaker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2acc27dac8330aa672e8232bd771b