### PR TITLE
Prevent drivers from requesting their own rides

### DIFF
--- a/src/lib/firestore-rides.ts
+++ b/src/lib/firestore-rides.ts
@@ -149,6 +149,13 @@ export async function requestRide(input: RequestRideInput) {
 
     const rideData = rideSnap.data() as DocumentData;
 
+    if ((rideData.driverUid ?? null) === input.passengerUid) {
+      return {
+        success: false as const,
+        message: "No podés solicitar tu propio viaje.",
+      };
+    }
+
     if ((rideData.availableSeats ?? 0) <= 0) {
       return {
         success: false as const,


### PR DESCRIPTION
## Summary
- validate ride requests to block drivers from requesting their own rides
- provide a clear error message when the passenger matches the driver

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2acc6992c8330a8ab535dde900fb0