### PR TITLE
Add ride subscription filtering support

### DIFF
--- a/src/app/viajes/page.tsx
+++ b/src/app/viajes/page.tsx
@@ -10,7 +10,10 @@ import { SearchRidesForm } from "@/components/rides/search-rides-form";
 import { AlertCircle, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { subscribeToAllRides } from "@/lib/firestore-rides";
+import {
+  subscribeToAllRides,
+  type RideSubscriptionFilters,
+} from "@/lib/firestore-rides";
 
 function RideListings() {
   const searchParams = useSearchParams();
@@ -18,26 +21,60 @@ function RideListings() {
   const destination = searchParams.get('destination');
   const date = searchParams.get('date'); // Formato esperado YYYY-MM-DD
 
+  const normalizedOrigin = origin?.trim() || undefined;
+  const normalizedDestination = destination?.trim() || undefined;
+
   const [rides, setRides] = useState<Ride[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = subscribeToAllRides((incomingRides) => {
+    let unsubscribe: (() => void) | undefined;
+
+    if (!date || !normalizedOrigin || !normalizedDestination) {
+      setRides([]);
+      setIsLoading(false);
+
+      return () => {
+        if (unsubscribe) {
+          unsubscribe();
+        }
+      };
+    }
+
+    setIsLoading(true);
+
+    const filters: RideSubscriptionFilters = {
+      date,
+      origin: normalizedOrigin,
+      destination: normalizedDestination,
+    };
+
+    unsubscribe = subscribeToAllRides((incomingRides) => {
       setRides(incomingRides);
       setIsLoading(false);
-    });
+    }, filters);
 
-    return () => unsubscribe();
-  }, []);
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [date, normalizedOrigin, normalizedDestination]);
 
   const filteredRides = useMemo(() => {
+    const originQuery = normalizedOrigin?.toLowerCase();
+    const destinationQuery = normalizedDestination?.toLowerCase();
+
     return rides
       .filter((ride) => {
         let matches = true;
-        if (origin && !ride.origin.toLowerCase().includes(origin.toLowerCase())) {
+        if (originQuery && !ride.origin.toLowerCase().includes(originQuery)) {
           matches = false;
         }
-        if (destination && !ride.destination.toLowerCase().includes(destination.toLowerCase())) {
+        if (
+          destinationQuery &&
+          !ride.destination.toLowerCase().includes(destinationQuery)
+        ) {
           matches = false;
         }
         if (date && ride.date !== date) {
@@ -49,10 +86,10 @@ function RideListings() {
       .sort(
         (a, b) => (a.createdAt?.getTime() || 0) - (b.createdAt?.getTime() || 0),
       );
-  }, [rides, origin, destination, date]);
+  }, [rides, normalizedOrigin, normalizedDestination, date]);
 
 
-  if (!origin && !destination && !date) {
+  if (!normalizedOrigin && !normalizedDestination && !date) {
     return (
       <div className="text-center py-10">
         <AlertCircle className="mx-auto h-12 w-12 text-muted-foreground mb-4" />

--- a/src/lib/firestore-rides.ts
+++ b/src/lib/firestore-rides.ts
@@ -16,6 +16,7 @@ import {
   updateDoc,
   writeBatch,
   where,
+  type QueryConstraint,
   type DocumentData,
   type DocumentSnapshot,
   type QueryDocumentSnapshot,
@@ -505,12 +506,32 @@ export function subscribeToPassengerRequests(
   });
 }
 
-export function subscribeToAllRides(callback: (rides: Ride[]) => void) {
-  const ridesQuery = query(
-    collection(db, RIDES_COLLECTION),
-    orderBy("createdAt", "desc"),
-    limit(100),
-  );
+export type RideSubscriptionFilters = Partial<
+  Pick<Ride, "date" | "origin" | "destination">
+>;
+
+export function subscribeToAllRides(
+  callback: (rides: Ride[]) => void,
+  filters: RideSubscriptionFilters = {},
+) {
+  const constraints: QueryConstraint[] = [];
+
+  if (filters.date) {
+    constraints.push(where("date", "==", filters.date));
+  }
+
+  if (filters.origin) {
+    constraints.push(where("origin", "==", filters.origin));
+  }
+
+  if (filters.destination) {
+    constraints.push(where("destination", "==", filters.destination));
+  }
+
+  constraints.push(orderBy("createdAt", "desc"));
+  constraints.push(limit(100));
+
+  const ridesQuery = query(collection(db, RIDES_COLLECTION), ...constraints);
 
   return onSnapshot(ridesQuery, (snapshot) => {
     const rides = snapshot.docs.map((docSnap) => mapRideSnapshot(docSnap));


### PR DESCRIPTION
## Summary
- allow subscribeToAllRides to accept optional Firestore filters before ordering
- sanitize search params and subscribe only when filters are present on the rides page
- resubscribe when filters change and keep UI filtering logic in sync with sanitized values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2acd59a848330bb461ae665161dfd