### PR TITLE
Improve navbar mobile accessibility

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -122,7 +122,7 @@ export function Navbar() {
             <Car className="h-8 w-8" />
             <span className="text-xl font-bold">Rueda Compartida</span>
           </Link>
-          <div className="flex items-center space-x-2 sm:space-x-4">
+          <div className="flex items-center gap-2 sm:gap-4">
             <Button variant="ghost" size="sm" asChild className="hidden sm:inline-flex">
               <Link href="/buscar-viajes">
                 <Search className="mr-2 h-4 w-4" />
@@ -290,33 +290,71 @@ export function Navbar() {
               </>
             ) : (
               <>
-                <Button variant="ghost" size="sm" asChild>
+                <Button variant="ghost" size="sm" asChild className="hidden sm:inline-flex">
                   <Link href="/login">
-                    <LogIn className="mr-1 h-4 w-4 sm:mr-2" />
-                    <span className="hidden sm:inline">Iniciar Sesión</span>
+                    <LogIn className="mr-2 h-4 w-4" />
+                    Iniciar Sesión
                   </Link>
                 </Button>
-                <Button size="sm" asChild>
+                <Button size="sm" asChild className="hidden sm:inline-flex">
                   <Link href="/register">
-                    <UserPlus className="mr-1 h-4 w-4 sm:mr-2" />
-                    <span className="hidden sm:inline">Registrate</span>
+                    <UserPlus className="mr-2 h-4 w-4" />
+                    Registrate
                   </Link>
                 </Button>
               </>
             )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild className="sm:hidden">
-                <Button variant="ghost" size="icon">
+                <Button variant="ghost" size="icon" aria-label="Abrir el menú de navegación">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-menu"><line x1="4" x2="20" y1="12" y2="12"/><line x1="4" x2="20" y1="6" y2="6"/><line x1="4" x2="20" y1="18" y2="18"/></svg>
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem asChild>
-                  <Link href="/buscar-viajes">Buscar Viajes</Link>
+              <DropdownMenuContent align="end" sideOffset={8} className="w-56 space-y-1 p-2 sm:hidden">
+                <DropdownMenuItem asChild className="p-0">
+                  <Link
+                    href="/buscar-viajes"
+                    className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium"
+                    aria-label="Ir a la página para buscar viajes disponibles"
+                  >
+                    <Search className="h-4 w-4" />
+                    Buscar Viajes
+                  </Link>
                 </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link href="/crear-viaje">Ofrecer Viaje</Link>
+                <DropdownMenuItem asChild className="p-0">
+                  <Link
+                    href="/crear-viaje"
+                    className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium"
+                    aria-label="Ir a la página para ofrecer un nuevo viaje"
+                  >
+                    <PlusCircle className="h-4 w-4" />
+                    Ofrecer Viaje
+                  </Link>
                 </DropdownMenuItem>
+                {!user && (
+                  <>
+                    <DropdownMenuItem asChild className="p-0">
+                      <Link
+                        href="/login"
+                        className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium"
+                        aria-label="Ir a la página para iniciar sesión"
+                      >
+                        <LogIn className="h-4 w-4" />
+                        Iniciar Sesión
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="p-0">
+                      <Link
+                        href="/register"
+                        className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium"
+                        aria-label="Ir a la página para registrarse"
+                      >
+                        <UserPlus className="h-4 w-4" />
+                        Registrate
+                      </Link>
+                    </DropdownMenuItem>
+                  </>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>


### PR DESCRIPTION
## Summary
- ensure login and register actions remain visible on small screens by showing them in the mobile navigation menu
- add full-width mobile dropdown entries with descriptive aria-labels for search, offer, login and register actions and tighten navbar spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2c6ed5fc483309e3f5115b571d990