### PR TITLE
feat: improve ride forms date inputs on mobile

### DIFF
--- a/src/components/rides/create-ride-form.tsx
+++ b/src/components/rides/create-ride-form.tsx
@@ -26,11 +26,14 @@ import { createRide } from "@/lib/firestore-rides";
 import { useAuth } from "@/contexts/auth-provider";
 import { useRouter } from "next/navigation";
 import { rideFormSchema, type RideFormValues } from "@/lib/validators/ride";
+import { toLocalDate } from "@/lib/date";
+import { useMediaQuery } from "@/hooks/use-media-query";
 
 export function CreateRideForm() {
   const { toast } = useToast();
   const { user } = useAuth();
   const router = useRouter();
+  const isDesktop = useMediaQuery("(min-width: 640px)");
 
   const form = useForm<RideFormValues>({
     resolver: zodResolver(rideFormSchema),
@@ -119,35 +122,54 @@ export function CreateRideForm() {
             render={({ field }) => (
               <FormItem className="flex flex-col">
                 <FormLabel>Fecha</FormLabel>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <FormControl>
-                      <Button
-                        variant={"outline"}
-                        className={cn(
-                          "w-full pl-3 text-left font-normal",
-                          !field.value && "text-muted-foreground"
-                        )}
-                      >
-                        {field.value ? (
-                          format(field.value, "PPP")
-                        ) : (
-                          <span>Seleccioná una fecha</span>
-                        )}
-                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                      </Button>
-                    </FormControl>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar
-                      mode="single"
-                      selected={field.value}
-                      onSelect={field.onChange}
-                      disabled={(date) => date < new Date(new Date().setDate(new Date().getDate() - 1))} // Fechas pasadas deshabilitadas
-                      initialFocus
+                {isDesktop ? (
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant={"outline"}
+                          className={cn(
+                            "w-full pl-3 text-left font-normal",
+                            !field.value && "text-muted-foreground"
+                          )}
+                        >
+                          {field.value ? (
+                            format(field.value, "PPP")
+                          ) : (
+                            <span>Seleccioná una fecha</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value}
+                        onSelect={field.onChange}
+                        disabled={(date) =>
+                          date < new Date(new Date().setDate(new Date().getDate() - 1))
+                        } // Fechas pasadas deshabilitadas
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                ) : (
+                  <FormControl>
+                    <Input
+                      type="date"
+                      value={field.value ? format(field.value, "yyyy-MM-dd") : ""}
+                      min={format(new Date(), "yyyy-MM-dd")}
+                      onChange={(event) => {
+                        const nextValue = toLocalDate(event.target.value);
+                        field.onChange(nextValue ?? undefined);
+                      }}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                      ref={field.ref}
                     />
-                  </PopoverContent>
-                </Popover>
+                  </FormControl>
+                )}
                 <FormMessage />
               </FormItem>
             )}

--- a/src/components/rides/search-rides-form.tsx
+++ b/src/components/rides/search-rides-form.tsx
@@ -26,11 +26,26 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { cn } from "@/lib/utils";
 import { toLocalDate } from "@/lib/date";
+import { useMediaQuery } from "@/hooks/use-media-query";
 
 const searchRidesSchema = z.object({
   origin: z.string().min(1, "El origen es requerido."),
   destination: z.string().min(1, "El destino es requerido."),
-  date: z.date({ required_error: "La fecha es requerida." }),
+  date: z.preprocess(
+    (value) => {
+      if (value instanceof Date) {
+        return value;
+      }
+
+      if (typeof value === "string") {
+        const parsed = toLocalDate(value);
+        return parsed ?? value;
+      }
+
+      return value;
+    },
+    z.date({ required_error: "La fecha es requerida." })
+  ),
 });
 
 type SearchRidesFormValues = z.infer<typeof searchRidesSchema>;
@@ -38,6 +53,7 @@ type SearchRidesFormValues = z.infer<typeof searchRidesSchema>;
 export function SearchRidesForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const isDesktop = useMediaQuery("(min-width: 640px)");
 
   const dateParam = searchParams.get("date");
   const parsedDate = dateParam ? toLocalDate(dateParam) : null;
@@ -97,35 +113,54 @@ export function SearchRidesForm() {
             render={({ field }) => (
               <FormItem className="flex flex-col">
                 <FormLabel>Fecha</FormLabel>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <FormControl>
-                      <Button
-                        variant={"outline"}
-                        className={cn(
-                          "w-full pl-3 text-left font-normal h-10",
-                          !field.value && "text-muted-foreground"
-                        )}
-                      >
-                        {field.value ? (
-                          format(field.value, "PPP", { locale: es })
-                        ) : (
-                          <span>Seleccioná una fecha</span>
-                        )}
-                        <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                      </Button>
-                    </FormControl>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar
-                      mode="single"
-                      selected={field.value}
-                      onSelect={field.onChange}
-                      disabled={(date) => date < new Date(new Date().setDate(new Date().getDate() - 1))}
-                      initialFocus
+                {isDesktop ? (
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant={"outline"}
+                          className={cn(
+                            "w-full pl-3 text-left font-normal h-10",
+                            !field.value && "text-muted-foreground"
+                          )}
+                        >
+                          {field.value ? (
+                            format(field.value, "PPP", { locale: es })
+                          ) : (
+                            <span>Seleccioná una fecha</span>
+                          )}
+                          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={field.value}
+                        onSelect={field.onChange}
+                        disabled={(date) =>
+                          date < new Date(new Date().setDate(new Date().getDate() - 1))
+                        }
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                ) : (
+                  <FormControl>
+                    <Input
+                      type="date"
+                      value={field.value ? format(field.value, "yyyy-MM-dd") : ""}
+                      min={format(new Date(), "yyyy-MM-dd")}
+                      onChange={(event) => {
+                        const nextValue = toLocalDate(event.target.value);
+                        field.onChange(nextValue ?? undefined);
+                      }}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                      ref={field.ref}
                     />
-                  </PopoverContent>
-                </Popover>
+                  </FormControl>
+                )}
                 <FormMessage />
               </FormItem>
             )}

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+export function useMediaQuery(query: string) {
+  const getMatches = React.useCallback(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return window.matchMedia(query).matches;
+  }, [query]);
+
+  const [matches, setMatches] = React.useState<boolean>(getMatches);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(query);
+    const updateMatches = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQueryList.matches);
+
+    if (typeof mediaQueryList.addEventListener === "function") {
+      mediaQueryList.addEventListener("change", updateMatches);
+      return () => {
+        mediaQueryList.removeEventListener("change", updateMatches);
+      };
+    }
+
+    mediaQueryList.addListener(updateMatches);
+    return () => {
+      mediaQueryList.removeListener(updateMatches);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/src/lib/validators/ride.ts
+++ b/src/lib/validators/ride.ts
@@ -1,9 +1,25 @@
 import { z } from "zod";
 
+import { toLocalDate } from "@/lib/date";
+
 export const rideFormSchema = z.object({
   origin: z.string().min(3, "El origen debe tener al menos 3 caracteres."),
   destination: z.string().min(3, "El destino debe tener al menos 3 caracteres."),
-  date: z.date({ required_error: "La fecha es requerida." }),
+  date: z.preprocess(
+    (value) => {
+      if (value instanceof Date) {
+        return value;
+      }
+
+      if (typeof value === "string") {
+        const parsed = toLocalDate(value);
+        return parsed ?? value;
+      }
+
+      return value;
+    },
+    z.date({ required_error: "La fecha es requerida." })
+  ),
   time: z
     .string()
     .regex(/^([01]\d|2[0-3]):([0-5]\d)$/u, "Formato de hora inválido (HH:MM)."),


### PR DESCRIPTION
## Summary
- add a useMediaQuery hook to detect the sm breakpoint
- switch ride search and creation forms to native date inputs on small screens while keeping the calendar popover on desktop
- allow Zod validators to parse string dates so native inputs remain compatible

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2c6fb0e608330aea61c21d72ba167