### PR TITLE
Improve dashboard summary grid responsiveness

### DIFF
--- a/src/app/dashboard/conductor/page.tsx
+++ b/src/app/dashboard/conductor/page.tsx
@@ -380,6 +380,8 @@ export default function DriverDashboardPage() {
     }
   }, [ridesWithRequests, selectedFilter]);
 
+  const summaryTileClass = "space-y-1 rounded-lg border border-border/60 p-3";
+
   if (loading || !user) {
     return (
       <AppLayout>
@@ -436,24 +438,24 @@ export default function DriverDashboardPage() {
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             Resumen rápido
           </h2>
-          <div className="mt-3 grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-            <div className="space-y-1">
+          <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Publicados</p>
               <p className="text-lg font-semibold">{driverStats.totalRides}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Solicitudes</p>
               <p className="text-lg font-semibold">{driverStats.totalRequests}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Pendientes</p>
               <p className="text-lg font-semibold">{driverStats.pendingRequests}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Contraofertas</p>
               <p className="text-lg font-semibold">{driverStats.counteredRequests}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Confirmados</p>
               <p className="text-lg font-semibold">{driverStats.acceptedRequests}</p>
             </div>

--- a/src/app/dashboard/pasajero/page.tsx
+++ b/src/app/dashboard/pasajero/page.tsx
@@ -157,6 +157,8 @@ export default function PassengerDashboardPage() {
     { value: "rejected", label: "Rechazadas", count: stats.rejected },
   ];
 
+  const summaryTileClass = "space-y-1 rounded-lg border border-border/60 p-3";
+
   if (loading || !user) {
     return (
       <AppLayout>
@@ -201,24 +203,24 @@ export default function PassengerDashboardPage() {
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             Resumen rápido
           </h2>
-          <div className="mt-3 grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-            <div className="space-y-1">
+          <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Enviadas</p>
               <p className="text-lg font-semibold">{stats.total}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Pendientes</p>
               <p className="text-lg font-semibold">{stats.pending}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Contraofertas</p>
               <p className="text-lg font-semibold">{stats.countered}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Confirmadas</p>
               <p className="text-lg font-semibold">{stats.accepted}</p>
             </div>
-            <div className="space-y-1">
+            <div className={summaryTileClass}>
               <p className="text-xs uppercase text-muted-foreground">Rechazadas</p>
               <p className="text-lg font-semibold">{stats.rejected}</p>
             </div>


### PR DESCRIPTION
## Summary
- ensure the driver dashboard summary tiles use a two-column grid on small screens while keeping existing desktop breakpoints and adding padding for readability
- mirror the mobile grid and spacing adjustments in the passenger dashboard summary for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ca34edc88330923ffa0d245948ab