### PR TITLE
Refine dashboard overview and summary

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { AppLayout } from "@/components/layout/app-layout";
 import { Button } from "@/components/ui/button";
@@ -7,10 +8,17 @@ import {
   Card,
   CardContent,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
 import { useAuthGuard } from "@/hooks/use-auth-guard";
+import type { Ride, RideRequest } from "@/types";
+import {
+  subscribeToDriverRequests,
+  subscribeToDriverRides,
+  subscribeToPassengerRequests,
+} from "@/lib/firestore-rides";
 import type { LucideIcon } from "lucide-react";
 import {
   Bell,
@@ -24,7 +32,7 @@ import {
   Users,
 } from "lucide-react";
 
-type DashboardAction = {
+type QuickAction = {
   title: string;
   description: string;
   href: string;
@@ -38,7 +46,7 @@ type HighlightItem = {
   icon: LucideIcon;
 };
 
-const quickActions: DashboardAction[] = [
+const quickActions: QuickAction[] = [
   {
     title: "Buscar viajes disponibles",
     description:
@@ -54,22 +62,6 @@ const quickActions: DashboardAction[] = [
     href: "/crear-viaje",
     label: "Crear viaje",
     icon: PlusCircle,
-  },
-  {
-    title: "Panel de pasajero",
-    description:
-      "Seguí el estado de tus reservas, aceptá propuestas y respondé mensajes de los conductores en tiempo real.",
-    href: "/dashboard/pasajero",
-    label: "Abrir panel pasajero",
-    icon: Users,
-  },
-  {
-    title: "Panel de conductor",
-    description:
-      "Gestioná tus viajes publicados, respondé solicitudes y confirmá pasajeros desde un único lugar.",
-    href: "/dashboard/conductor",
-    label: "Abrir panel conductor",
-    icon: Car,
   },
 ];
 
@@ -94,46 +86,277 @@ const highlights: HighlightItem[] = [
   },
 ];
 
+type PassengerSummary = {
+  confirmed: number;
+  pending: number;
+  countered: number;
+  total: number;
+};
+
+type DriverSummary = {
+  confirmedRides: number;
+  pendingRequests: number;
+  counteredRequests: number;
+  totalRides: number;
+};
+
 export default function DashboardPage() {
   const { user } = useAuthGuard();
+  const [passengerRequests, setPassengerRequests] = useState<RideRequest[]>([]);
+  const [driverRequests, setDriverRequests] = useState<RideRequest[]>([]);
+  const [driverRides, setDriverRides] = useState<Ride[]>([]);
+  const [isLoadingSummary, setIsLoadingSummary] = useState(true);
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setPassengerRequests([]);
+      setDriverRequests([]);
+      setDriverRides([]);
+      setIsLoadingSummary(false);
+      return undefined;
+    }
+
+    setIsLoadingSummary(true);
+
+    let passengerReady = false;
+    let driverRequestsReady = false;
+    let driverRidesReady = false;
+
+    const markReady = () => {
+      if (passengerReady && driverRequestsReady && driverRidesReady) {
+        setIsLoadingSummary(false);
+      }
+    };
+
+    const unsubscribePassenger = subscribeToPassengerRequests(
+      user.uid,
+      (requests) => {
+        passengerReady = true;
+        setPassengerRequests(
+          requests.map((request) => ({
+            ...request,
+            passengerName:
+              request.passengerName
+              || user.displayName
+              || user.email
+              || "Yo",
+          })),
+        );
+        markReady();
+      },
+    );
+
+    const unsubscribeDriverRequests = subscribeToDriverRequests(
+      user.uid,
+      (requests) => {
+        driverRequestsReady = true;
+        setDriverRequests(requests);
+        markReady();
+      },
+    );
+
+    const unsubscribeDriverRides = subscribeToDriverRides(
+      user.uid,
+      (rides) => {
+        driverRidesReady = true;
+        setDriverRides(
+          rides.map((ride) => ({
+            ...ride,
+            driverName:
+              ride.driverName || user.displayName || user.email || "Yo",
+          })),
+        );
+        markReady();
+      },
+    );
+
+    return () => {
+      unsubscribePassenger();
+      unsubscribeDriverRequests();
+      unsubscribeDriverRides();
+    };
+  }, [user?.uid, user?.displayName, user?.email]);
+
+  const passengerSummary = useMemo<PassengerSummary>(() => {
+    const summary: PassengerSummary = {
+      confirmed: 0,
+      pending: 0,
+      countered: 0,
+      total: passengerRequests.length,
+    };
+
+    passengerRequests.forEach((request) => {
+      switch (request.status) {
+        case "accepted":
+          summary.confirmed += 1;
+          break;
+        case "pending":
+          summary.pending += 1;
+          break;
+        case "countered":
+          summary.countered += 1;
+          break;
+        default:
+          break;
+      }
+    });
+
+    return summary;
+  }, [passengerRequests]);
+
+  const driverSummary = useMemo<DriverSummary>(() => {
+    const summary: DriverSummary = {
+      confirmedRides: 0,
+      pendingRequests: 0,
+      counteredRequests: 0,
+      totalRides: driverRides.length,
+    };
+
+    const ridesWithAccepted = new Set<string>();
+
+    driverRequests.forEach((request) => {
+      if (request.status === "pending") {
+        summary.pendingRequests += 1;
+      }
+      if (request.status === "countered") {
+        summary.counteredRequests += 1;
+      }
+      if (request.status === "accepted" && request.rideId) {
+        ridesWithAccepted.add(request.rideId);
+      }
+    });
+
+    summary.confirmedRides = ridesWithAccepted.size;
+
+    return summary;
+  }, [driverRequests, driverRides.length]);
 
   const greetingName = user?.displayName?.split(" ")[0]
     || user?.email?.split("@")[0]
     || "tripulante";
+
+  const passengerPendingTotal = passengerSummary.pending + passengerSummary.countered;
+  const driverPendingTotal = driverSummary.pendingRequests + driverSummary.counteredRequests;
 
   return (
     <AppLayout>
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 py-6 sm:py-10">
         <section className="rounded-3xl border border-border/60 bg-card/80 p-6 shadow-sm sm:p-10">
           <div className="flex flex-col gap-6 text-center sm:text-left">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="space-y-3 text-balance">
-                <p className="text-sm font-medium uppercase tracking-wide text-primary/90">
-                  Tu centro de operaciones
-                </p>
-                <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
-                  Hola, {greetingName}! 👋
-                </h1>
-                <p className="text-sm text-muted-foreground sm:text-base">
-                  Elegí por dónde empezar: buscá un viaje como pasajero, publicá tu recorrido como conductor o revisá tus solicitudes y notificaciones.
-                </p>
-              </div>
-              <div className="grid w-full gap-3 sm:w-auto">
-                <Button asChild size="lg" className="w-full">
-                  <Link href="/buscar-viajes">
-                    <Search className="mr-2 h-5 w-5" />
-                    Buscar viajes
-                  </Link>
-                </Button>
-                <Button asChild size="lg" variant="outline" className="w-full">
-                  <Link href="/crear-viaje">
-                    <PlusCircle className="mr-2 h-5 w-5" />
-                    Crear un viaje
-                  </Link>
-                </Button>
-              </div>
+            <div className="space-y-3 text-balance">
+              <p className="text-sm font-medium uppercase tracking-wide text-primary/90">
+                Tu centro de operaciones
+              </p>
+              <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                Hola, {greetingName}! 👋
+              </h1>
+              <p className="text-sm text-muted-foreground sm:text-base">
+                Tené a mano un resumen de tus viajes confirmados y las solicitudes pendientes que necesitan tu atención.
+              </p>
             </div>
           </div>
+        </section>
+
+        <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <Card className="flex h-full flex-col justify-between border border-border/60 bg-background/70 shadow-sm">
+            <CardHeader className="flex flex-row items-start gap-4">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Users className="h-5 w-5" />
+              </div>
+              <div className="space-y-2">
+                <CardTitle className="text-lg font-semibold leading-tight text-foreground">
+                  Actividad como pasajero
+                </CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  Revisá tus viajes confirmados y respondé las solicitudes que siguen abiertas.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-0">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-lg border border-border/60 bg-card/70 p-4 text-center">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Viajes confirmados
+                  </p>
+                  <p className="text-3xl font-semibold text-foreground">
+                    {isLoadingSummary ? "--" : passengerSummary.confirmed}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border/60 bg-card/70 p-4 text-center">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Solicitudes pendientes
+                  </p>
+                  <p className="text-3xl font-semibold text-foreground">
+                    {isLoadingSummary ? "--" : passengerPendingTotal}
+                  </p>
+                </div>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {isLoadingSummary
+                  ? "Cargando tu actividad más reciente..."
+                  : passengerSummary.total === 0
+                    ? "Todavía no enviaste solicitudes. Buscá un viaje para comenzar."
+                    : passengerPendingTotal > 0
+                      ? "Tenés solicitudes por confirmar o contraofertas para revisar."
+                      : "Todo al día: no hay solicitudes pendientes."}
+              </p>
+            </CardContent>
+            <CardFooter>
+              <Button asChild className="w-full" variant="outline">
+                <Link href="/dashboard/pasajero">Ir al panel de pasajero</Link>
+              </Button>
+            </CardFooter>
+          </Card>
+
+          <Card className="flex h-full flex-col justify-between border border-border/60 bg-background/70 shadow-sm">
+            <CardHeader className="flex flex-row items-start gap-4">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <Car className="h-5 w-5" />
+              </div>
+              <div className="space-y-2">
+                <CardTitle className="text-lg font-semibold leading-tight text-foreground">
+                  Actividad como conductor
+                </CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  Seguí tus viajes publicados y las solicitudes que necesitan respuesta.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-0">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-lg border border-border/60 bg-card/70 p-4 text-center">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Viajes con pasajeros confirmados
+                  </p>
+                  <p className="text-3xl font-semibold text-foreground">
+                    {isLoadingSummary ? "--" : driverSummary.confirmedRides}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border/60 bg-card/70 p-4 text-center">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Solicitudes por responder
+                  </p>
+                  <p className="text-3xl font-semibold text-foreground">
+                    {isLoadingSummary ? "--" : driverPendingTotal}
+                  </p>
+                </div>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {isLoadingSummary
+                  ? "Consultando tus publicaciones activas..."
+                  : driverSummary.totalRides === 0
+                    ? "Todavía no publicaste viajes. Creá uno para comenzar a recibir solicitudes."
+                    : driverPendingTotal > 0
+                      ? "Tenés solicitudes pendientes o contraofertas a revisar."
+                      : "Todo listo: no hay solicitudes pendientes por responder."}
+              </p>
+            </CardContent>
+            <CardFooter>
+              <Button asChild className="w-full" variant="outline">
+                <Link href="/dashboard/conductor">Ir al panel de conductor</Link>
+              </Button>
+            </CardFooter>
+          </Card>
         </section>
 
         <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- add live passenger and driver summaries on the dashboard fed by Firestore subscriptions
- restructure the hero and quick actions to avoid duplicated information and CTAs
- highlight confirmed trips and pending requests with direct links to the passenger and driver panels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4348a1bd48330943b6e3e26ccd9ac