### PR TITLE
feat: enable sharing ride links with metadata

### DIFF
--- a/src/app/viajes/[rideId]/page.tsx
+++ b/src/app/viajes/[rideId]/page.tsx
@@ -1,0 +1,121 @@
+import type { Metadata } from "next";
+import { AppLayout } from "@/components/layout/app-layout";
+import { RideShareDetails, type RideShareFallback } from "@/components/rides/ride-share-details";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const APP_BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined);
+
+type RideSharePageProps = {
+  params: { rideId: string };
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+function getSingleValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function parseNumber(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function buildFallback(searchParams: RideSharePageProps["searchParams"]): RideShareFallback {
+  return {
+    origin: getSingleValue(searchParams.origin),
+    destination: getSingleValue(searchParams.destination),
+    date: getSingleValue(searchParams.date),
+    time: getSingleValue(searchParams.time),
+    driverName: getSingleValue(searchParams.driverName),
+    price: parseNumber(getSingleValue(searchParams.price)),
+    availableSeats: parseNumber(getSingleValue(searchParams.availableSeats)),
+  };
+}
+
+function buildDescription(fallback: RideShareFallback): string {
+  const segments: string[] = [];
+
+  if (fallback.origin && fallback.destination) {
+    segments.push(`Desde ${fallback.origin} hacia ${fallback.destination}`);
+  }
+
+  if (fallback.date) {
+    segments.push(`Fecha ${fallback.date}`);
+  }
+
+  if (fallback.time) {
+    segments.push(`Hora ${fallback.time}`);
+  }
+
+  if (typeof fallback.price === "number") {
+    segments.push(`Valor sugerido $${fallback.price.toFixed(2)}`);
+  }
+
+  return (
+    segments.join(" · ") ||
+    "Conocé los detalles de este viaje compartido en Rueda Compartida y solicitá tu lugar."
+  );
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: RideSharePageProps): Promise<Metadata> {
+  const fallback = buildFallback(searchParams);
+  const titleBase = fallback.origin && fallback.destination
+    ? `${fallback.origin} a ${fallback.destination}`
+    : "Viaje compartido";
+  const title = `${titleBase} | Rueda Compartida`;
+  const description = buildDescription(fallback);
+  const absoluteUrl = APP_BASE_URL
+    ? new URL(`/viajes/${params.rideId}`, APP_BASE_URL).toString()
+    : undefined;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      url: absoluteUrl,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default function RideSharePage({ params, searchParams }: RideSharePageProps) {
+  const fallbackRide = buildFallback(searchParams);
+
+  return (
+    <AppLayout>
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <Card className="shadow-lg">
+          <CardHeader>
+            <CardTitle className="text-3xl">
+              Invitá pasajeros a tu viaje compartido
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-muted-foreground">
+            Compartí este enlace para que otras personas vean la información del viaje y soliciten un lugar de forma segura.
+          </CardContent>
+        </Card>
+
+        <RideShareDetails rideId={params.rideId} fallbackRide={fallbackRide} />
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/components/rides/ride-card.tsx
+++ b/src/components/rides/ride-card.tsx
@@ -20,6 +20,7 @@ import {
   CircleDollarSign,
   CheckCircle,
   AlertTriangle,
+  Share2,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/auth-provider";
@@ -32,9 +33,10 @@ import { toLocalDate } from "@/lib/date";
 
 interface RideCardProps {
   ride: Ride;
+  showShareButton?: boolean;
 }
 
-export function RideCard({ ride }: RideCardProps) {
+export function RideCard({ ride, showShareButton = true }: RideCardProps) {
   const { toast } = useToast();
   const { user } = useAuth();
   const [isRequesting, setIsRequesting] = useState(false);
@@ -122,6 +124,75 @@ export function RideCard({ ride }: RideCardProps) {
     setIsRequesting(false);
   };
 
+  const handleShareRide = async () => {
+    if (!ride.id) {
+      toast({
+        title: "No se puede compartir",
+        description: "El viaje no tiene un identificador válido.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      const origin = typeof window !== "undefined" ? window.location.origin : "";
+      const appBaseUrl = origin || "https://rueda-compartida.web.app";
+      const shareUrl = new URL(`/viajes/${ride.id}`, appBaseUrl);
+
+      shareUrl.searchParams.set("origin", ride.origin);
+      shareUrl.searchParams.set("destination", ride.destination);
+      shareUrl.searchParams.set("date", ride.date);
+      shareUrl.searchParams.set("time", ride.time);
+      shareUrl.searchParams.set("price", ride.price.toString());
+      shareUrl.searchParams.set(
+        "availableSeats",
+        ride.availableSeats.toString(),
+      );
+      if (ride.driverName) {
+        shareUrl.searchParams.set("driverName", ride.driverName);
+      }
+
+      const shareTitle = `${ride.origin} a ${ride.destination}`;
+      const shareText = `Salida el ${formattedRideDate} a las ${ride.time}. ${ride.availableSeats} lugares disponibles a $${ride.price.toFixed(2)}.`;
+
+      if (navigator.share) {
+        await navigator.share({
+          title: `Viaje compartido: ${shareTitle}`,
+          text: shareText,
+          url: shareUrl.toString(),
+        });
+        toast({
+          title: "Enlace compartido",
+          description: "Tu viaje se abrió en el diálogo de compartir.",
+        });
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(shareUrl.toString());
+        toast({
+          title: "Enlace copiado",
+          description: "Pegá el enlace para invitar pasajeros a tu viaje.",
+        });
+      } else {
+        toast({
+          title: "No se pudo compartir",
+          description: "Tu dispositivo no permite compartir enlaces automáticamente.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return;
+      }
+
+      console.error("Error al compartir el viaje", error);
+      toast({
+        title: "No se pudo compartir",
+        description: "Ocurrió un error al generar el enlace del viaje.",
+        variant: "destructive",
+        action: <AlertTriangle className="text-red-500" />,
+      });
+    }
+  };
+
   return (
     <Card className="w-full shadow-lg hover:shadow-primary/20 transition-shadow">
       <CardHeader>
@@ -154,20 +225,31 @@ export function RideCard({ ride }: RideCardProps) {
           <span>${ride.price.toFixed(2)}</span>
         </div>
       </CardContent>
-      <CardFooter>
-        {user?.uid !== ride.driverUid ? (
+      <CardFooter className="flex flex-col gap-2 sm:flex-row">
+        <div className="flex w-full sm:flex-1">
+          {user?.uid !== ride.driverUid ? (
+            <Button
+              className="w-full"
+              onClick={handleOpenOfferDialog}
+              disabled={ride.availableSeats === 0}
+            >
+              {ride.availableSeats > 0
+                ? "Solicitar Viaje"
+                : "No Hay Lugares Disponibles"}
+            </Button>
+          ) : (
+            <Button className="w-full" disabled variant="outline">
+              Este es tu viaje
+            </Button>
+          )}
+        </div>
+        {showShareButton && (
           <Button
-            className="w-full"
-            onClick={handleOpenOfferDialog}
-            disabled={ride.availableSeats === 0}
+            className="w-full sm:w-auto"
+            onClick={handleShareRide}
+            variant="secondary"
           >
-            {ride.availableSeats > 0
-              ? "Solicitar Viaje"
-              : "No Hay Lugares Disponibles"}
-          </Button>
-        ) : (
-          <Button className="w-full" disabled variant="outline">
-            Este es tu viaje
+            <Share2 className="mr-2 h-4 w-4" /> Compartir
           </Button>
         )}
       </CardFooter>

--- a/src/components/rides/ride-share-details.tsx
+++ b/src/components/rides/ride-share-details.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { RideCard } from "@/components/rides/ride-card";
+import { getRideById } from "@/lib/firestore-rides";
+import type { Ride } from "@/types";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  CalendarDays,
+  Clock,
+  Loader2,
+  MapPin,
+  Users,
+  CircleDollarSign,
+} from "lucide-react";
+import { toLocalDate } from "@/lib/date";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+
+export type RideShareFallback = {
+  origin?: string;
+  destination?: string;
+  date?: string;
+  time?: string;
+  price?: number;
+  availableSeats?: number;
+  driverName?: string;
+};
+
+interface RideShareDetailsProps {
+  rideId: string;
+  fallbackRide?: RideShareFallback;
+}
+
+export function RideShareDetails({ rideId, fallbackRide }: RideShareDetailsProps) {
+  const [ride, setRide] = useState<Ride | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function fetchRide() {
+      setIsLoading(true);
+
+      const fetchedRide = await getRideById(rideId);
+
+      if (!isActive) {
+        return;
+      }
+
+      if (!fetchedRide) {
+        setRide(null);
+      } else {
+        setRide(fetchedRide);
+      }
+
+      setIsLoading(false);
+    }
+
+    fetchRide();
+
+    return () => {
+      isActive = false;
+    };
+  }, [rideId]);
+
+  const fallbackDate = useMemo(() => toLocalDate(fallbackRide?.date), [fallbackRide?.date]);
+  const formattedFallbackDate = useMemo(() => {
+    if (!fallbackRide?.date) {
+      return undefined;
+    }
+    return fallbackDate ? format(fallbackDate, "PPP", { locale: es }) : fallbackRide.date;
+  }, [fallbackDate, fallbackRide?.date]);
+
+  if (ride) {
+    return <RideCard ride={ride} />;
+  }
+
+  if (isLoading && fallbackRide) {
+    return (
+      <Card className="w-full shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-xl md:text-2xl">
+            {fallbackRide.origin && fallbackRide.destination
+              ? `${fallbackRide.origin} a ${fallbackRide.destination}`
+              : "Viaje compartido"}
+          </CardTitle>
+          {fallbackRide.driverName ? (
+            <CardDescription>Conductor: {fallbackRide.driverName}</CardDescription>
+          ) : null}
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {fallbackRide.date ? (
+            <div className="flex items-center text-sm text-muted-foreground">
+              <CalendarDays className="mr-2 h-4 w-4 text-primary" />
+              <span>{formattedFallbackDate}</span>
+            </div>
+          ) : null}
+          {fallbackRide.time ? (
+            <div className="flex items-center text-sm text-muted-foreground">
+              <Clock className="mr-2 h-4 w-4 text-primary" />
+              <span>{fallbackRide.time}</span>
+            </div>
+          ) : null}
+          {fallbackRide.origin ? (
+            <div className="flex items-center text-sm text-muted-foreground">
+              <MapPin className="mr-2 h-4 w-4 text-primary" />
+              <span>Desde: {fallbackRide.origin}</span>
+            </div>
+          ) : null}
+          {fallbackRide.destination ? (
+            <div className="flex items-center text-sm text-muted-foreground">
+              <MapPin className="mr-2 h-4 w-4 text-primary" />
+              <span>Hacia: {fallbackRide.destination}</span>
+            </div>
+          ) : null}
+          {typeof fallbackRide.availableSeats === "number" ? (
+            <div className="flex items-center text-sm">
+              <Users className="mr-2 h-4 w-4 text-primary" />
+              <span className="font-medium">
+                {fallbackRide.availableSeats} lugares disponibles
+              </span>
+            </div>
+          ) : null}
+          {typeof fallbackRide.price === "number" ? (
+            <div className="flex items-center text-lg font-semibold">
+              <CircleDollarSign className="mr-2 h-5 w-5 text-primary" />
+              <span>${fallbackRide.price.toFixed(2)}</span>
+            </div>
+          ) : null}
+        </CardContent>
+        <CardFooter className="text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Verificando la disponibilidad actualizada del viaje…</span>
+          </div>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>Viaje no disponible</AlertTitle>
+      <AlertDescription>
+        Es posible que el conductor haya cancelado el viaje o que ya no tenga lugares disponibles.
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/lib/firestore-rides.ts
+++ b/src/lib/firestore-rides.ts
@@ -29,6 +29,43 @@ const REQUESTS_COLLECTION = "rideRequests";
 
 export type CreateRideInput = Omit<Ride, "id" | "createdAt">;
 
+function mapRideDocument(snapshot: DocumentSnapshot<DocumentData>): Ride | null {
+  if (!snapshot.exists()) {
+    return null;
+  }
+
+  const data = snapshot.data() ?? {};
+
+  return {
+    id: snapshot.id,
+    driverUid: typeof data.driverUid === "string" ? data.driverUid : "",
+    driverName: typeof data.driverName === "string" ? data.driverName : "",
+    origin: typeof data.origin === "string" ? data.origin : "",
+    destination:
+      typeof data.destination === "string" ? data.destination : "",
+    date: typeof data.date === "string" ? data.date : "",
+    time: typeof data.time === "string" ? data.time : "",
+    availableSeats: Number(data.availableSeats ?? 0),
+    price: Number(data.price ?? 0),
+    createdAt:
+      data.createdAt && typeof data.createdAt.toDate === "function"
+        ? data.createdAt.toDate()
+        : undefined,
+  };
+}
+
+export async function getRideById(rideId: string): Promise<Ride | null> {
+  try {
+    const rideRef = doc(db, RIDES_COLLECTION, rideId);
+    const rideSnap = await getDoc(rideRef);
+
+    return mapRideDocument(rideSnap);
+  } catch (error) {
+    console.error("Error al obtener el viaje", error);
+    return null;
+  }
+}
+
 export async function createRide(input: CreateRideInput) {
   try {
     const docRef = await addDoc(collection(db, RIDES_COLLECTION), {


### PR DESCRIPTION
## Summary
- add a share button to ride cards that generates rich links with ride details
- expose a ride details share page with metadata for previews and request actions
- support fetching rides by id and display fallback information while loading shared pages

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d43ef258408330a96b1b872b03ee54