### PR TITLE
Handle ride search without Firestore index

### DIFF
--- a/src/lib/firestore-rides.ts
+++ b/src/lib/firestore-rides.ts
@@ -560,6 +560,10 @@ export function subscribeToAllRides(
 ) {
   const constraints: QueryConstraint[] = [];
 
+  const hasFilters = Boolean(
+    filters.date ?? filters.origin ?? filters.destination,
+  );
+
   if (filters.date) {
     constraints.push(where("date", "==", filters.date));
   }
@@ -572,14 +576,21 @@ export function subscribeToAllRides(
     constraints.push(where("destination", "==", filters.destination));
   }
 
-  constraints.push(orderBy("createdAt", "desc"));
-  constraints.push(limit(100));
+  if (!hasFilters) {
+    constraints.push(orderBy("createdAt", "desc"));
+    constraints.push(limit(100));
+  }
 
   const ridesQuery = query(collection(db, RIDES_COLLECTION), ...constraints);
 
   return onSnapshot(ridesQuery, (snapshot) => {
     const rides = snapshot.docs.map((docSnap) => mapRideSnapshot(docSnap));
-    callback(rides);
+
+    const sortedRides = rides.sort(
+      (a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0),
+    );
+
+    callback(hasFilters ? sortedRides.slice(0, 100) : sortedRides);
   });
 }
 


### PR DESCRIPTION
## Summary
- detect when ride filters are active and avoid Firestore ordering that needs composite indexes
- sort ride snapshots client-side and apply the 100 item limit after filtering to keep ordering consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d441c69b5c83309082d422fe45af4a