### PR TITLE
Mostrar sugerencias de viajes similares cuando no hay coincidencias

### DIFF
--- a/src/app/viajes/page.tsx
+++ b/src/app/viajes/page.tsx
@@ -14,7 +14,8 @@ import {
   subscribeToAllRides,
   type RideSubscriptionFilters,
 } from "@/lib/firestore-rides";
-import { getLocalDepartureDate } from '@/lib/date';
+import { getLocalDepartureDate } from "@/lib/date";
+import { differenceInCalendarDays, parseISO } from "date-fns";
 
 function RideListings() {
   const searchParams = useSearchParams();
@@ -26,18 +27,24 @@ function RideListings() {
   const normalizedDestination = destination?.trim() || undefined;
 
   const [rides, setRides] = useState<Ride[]>([]);
+  const [fallbackRides, setFallbackRides] = useState<Ride[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
+    let fallbackUnsubscribe: (() => void) | undefined;
 
     if (!date || !normalizedOrigin || !normalizedDestination) {
       setRides([]);
+      setFallbackRides([]);
       setIsLoading(false);
 
       return () => {
         if (unsubscribe) {
           unsubscribe();
+        }
+        if (fallbackUnsubscribe) {
+          fallbackUnsubscribe();
         }
       };
     }
@@ -55,9 +62,16 @@ function RideListings() {
       setIsLoading(false);
     }, filters);
 
+    fallbackUnsubscribe = subscribeToAllRides((incomingRides) => {
+      setFallbackRides(incomingRides);
+    });
+
     return () => {
       if (unsubscribe) {
         unsubscribe();
+      }
+      if (fallbackUnsubscribe) {
+        fallbackUnsubscribe();
       }
     };
   }, [date, normalizedOrigin, normalizedDestination]);
@@ -105,6 +119,108 @@ function RideListings() {
       });
   }, [rides, normalizedOrigin, normalizedDestination, date]);
 
+  const suggestedRides = useMemo(() => {
+    if (!normalizedOrigin || !normalizedDestination || !date) {
+      return [];
+    }
+
+    const normalizedOriginLower = normalizedOrigin.toLowerCase();
+    const normalizedDestinationLower = normalizedDestination.toLowerCase();
+    const filteredIds = new Set(
+      filteredRides.map((ride) => ride.id ?? `${ride.driverUid}-${ride.date}-${ride.time}`),
+    );
+
+    const targetDate = parseISO(date);
+    const isTargetDateValid = !Number.isNaN(targetDate.getTime());
+
+    const hasCommonWord = (text: string, query: string) => {
+      const textWords = text.split(/\s+/).map((word) => word.trim()).filter(Boolean);
+      const queryWords = query.split(/\s+/).map((word) => word.trim()).filter(Boolean);
+
+      return queryWords.some((queryWord) =>
+        textWords.some((word) => word.startsWith(queryWord) || word.includes(queryWord)),
+      );
+    };
+
+    return fallbackRides
+      .filter((ride) => {
+        const rideIdentifier = ride.id ?? `${ride.driverUid}-${ride.date}-${ride.time}`;
+        return ride.availableSeats > 0 && !filteredIds.has(rideIdentifier);
+      })
+      .map((ride) => {
+        const originLower = ride.origin.toLowerCase();
+        const destinationLower = ride.destination.toLowerCase();
+
+        let originScore = 0;
+        if (originLower === normalizedOriginLower) {
+          originScore = 5;
+        } else if (originLower.includes(normalizedOriginLower)) {
+          originScore = 3;
+        } else if (hasCommonWord(originLower, normalizedOriginLower)) {
+          originScore = 2;
+        }
+
+        let destinationScore = 0;
+        if (destinationLower === normalizedDestinationLower) {
+          destinationScore = 5;
+        } else if (destinationLower.includes(normalizedDestinationLower)) {
+          destinationScore = 3;
+        } else if (hasCommonWord(destinationLower, normalizedDestinationLower)) {
+          destinationScore = 2;
+        }
+
+        let dateScore = 0;
+        let dayDifference = Number.POSITIVE_INFINITY;
+        if (isTargetDateValid) {
+          const rideDate = parseISO(ride.date);
+          if (!Number.isNaN(rideDate.getTime())) {
+            dayDifference = Math.abs(differenceInCalendarDays(rideDate, targetDate));
+
+            if (dayDifference === 0) {
+              dateScore = 4;
+            } else if (dayDifference === 1) {
+              dateScore = 3;
+            } else if (dayDifference <= 3) {
+              dateScore = 2;
+            } else if (dayDifference <= 7) {
+              dateScore = 1;
+            }
+          }
+        }
+
+        const totalScore = originScore + destinationScore + dateScore;
+
+        return {
+          ride,
+          score: totalScore,
+          dayDifference,
+          createdAt: ride.createdAt?.getTime() ?? 0,
+          departureTimestamp: getLocalDepartureDate(ride)?.getTime() ?? Number.POSITIVE_INFINITY,
+        };
+      })
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => {
+        if (b.score !== a.score) {
+          return b.score - a.score;
+        }
+        if (a.dayDifference !== b.dayDifference) {
+          return a.dayDifference - b.dayDifference;
+        }
+        if (a.departureTimestamp !== b.departureTimestamp) {
+          return a.departureTimestamp - b.departureTimestamp;
+        }
+        return b.createdAt - a.createdAt;
+      })
+      .slice(0, 6)
+      .map(({ ride }) => ride);
+  }, [
+    date,
+    fallbackRides,
+    filteredRides,
+    normalizedDestination,
+    normalizedOrigin,
+  ]);
+
 
   if (!normalizedOrigin && !normalizedDestination && !date) {
     return (
@@ -136,12 +252,29 @@ function RideListings() {
       ))}
     </div>
   ) : (
-    <div className="text-center py-10">
-      <AlertCircle className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-      <h3 className="text-xl font-semibold">No Se Encontraron Viajes</h3>
-      <p className="text-muted-foreground">
-        Lo sentimos, ningún viaje coincide con tus criterios. Intentá con otras ubicaciones o fechas.
-      </p>
+    <div className="space-y-8">
+      <div className="text-center py-10">
+        <AlertCircle className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+        <h3 className="text-xl font-semibold">No Se Encontraron Viajes</h3>
+        <p className="text-muted-foreground">
+          Lo sentimos, ningún viaje coincide con tus criterios. Intentá con otras ubicaciones o fechas.
+        </p>
+      </div>
+
+      {suggestedRides.length > 0 && (
+        <div>
+          <h4 className="text-lg font-semibold mb-4 text-center md:text-left">
+            Opciones similares a tu búsqueda
+          </h4>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {suggestedRides.map((ride) => (
+              <RideCard key={ride.id ?? `${ride.driverUid}-${ride.date}-${ride.time}`}
+                ride={ride}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- añadir una suscripción secundaria para obtener viajes recientes y preparar sugerencias cuando no haya coincidencias exactas
- calcular la similitud por origen, destino y cercanía de fecha para priorizar los viajes alternativos
- mostrar un bloque de "Opciones similares" cuando la búsqueda original no devuelve resultados

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4450ef9e88330bed3b0041bc1df29