### PR TITLE
Add generateStaticParams placeholder for ride detail export

### DIFF
--- a/src/app/viajes/[rideId]/page.tsx
+++ b/src/app/viajes/[rideId]/page.tsx
@@ -12,6 +12,10 @@ type RideSharePageProps = {
   searchParams: Record<string, string | string[] | undefined>;
 };
 
+export function generateStaticParams(): RideSharePageProps["params"][] {
+  return [];
+}
+
 function getSingleValue(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) {
     return value[0];


### PR DESCRIPTION
## Summary
- add an empty `generateStaticParams` implementation for the ride detail page so the route can be exported when using `output: "export"`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d4495c76a08330bd1883b63ec04c7c